### PR TITLE
[core,lib] prioritize pubsub input subscription over topic

### DIFF
--- a/cli/src/klio_cli/commands/message/publish.py
+++ b/cli/src/klio_cli/commands/message/publish.py
@@ -40,7 +40,8 @@ def _get_current_klio_job(config):
     for input_ in inputs:
         job_input = klio_job.JobInput()
         job_input.topic = input_.topic
-        job_input.subscription = input_.subscription
+        if input_.subscription:
+            job_input.subscription = input_.subscription
         # [batch dev] TODO: hardcoding mapping between data and event
         # inputs for now (same behavior as v1)
         job_input.data_location = config.job_config.data_inputs[0].location

--- a/core/tests/config/test_config.py
+++ b/core/tests/config/test_config.py
@@ -521,3 +521,44 @@ def test_klio_write_bigquery_config_raises(schema):
         io.KlioBigQueryEventOutput.from_dict(
             config_dict, io.KlioIOType.EVENT, io.KlioIODirection.OUTPUT
         )
+
+
+@pytest.mark.parametrize(
+    "include_topic,include_subscription",
+    ((False, True), (True, False), (True, True),),
+)
+def test_pubsub_event_input_kwargs(include_topic, include_subscription):
+    config_dict = {
+        "type": "pubsub",
+        "topic": "a-topic",
+        "subscription": "a-subscription",
+    }
+
+    if not include_topic:
+        config_dict.pop("topic")
+    if not include_subscription:
+        config_dict.pop("subscription")
+
+    pubsub = io.KlioPubSubEventInput.from_dict(
+        config_dict, io.KlioIOType.EVENT, io.KlioIODirection.INPUT
+    )
+
+    if include_subscription:
+        expected = {
+            "subscription": "a-subscription",
+        }
+    else:
+        expected = {
+            "topic": "a-topic",
+        }
+
+    assert expected == pubsub.to_io_kwargs()
+
+
+def test_pubsub_event_input_topic_subscription():
+    config_dict = {"type": "pubsub"}
+
+    with pytest.raises(ValueError):
+        io.KlioPubSubEventInput.from_dict(
+            config_dict, io.KlioIOType.EVENT, io.KlioIODirection.INPUT
+        )


### PR DESCRIPTION
# Hey, I just made a Pull Request!


## Description

(this is a carryover from one of my internal PR's, but without backwards compatibility stuff)

This fixes a bug where `ReadFromPubsub` only accepts either `topic` or `subscription`, not both, but due to the way we're passing argument to it we're now attempting to pass both when we used to only ever use subscription.

So this will ensure that only one of them is passed in, prioritizing subscription over topic, but still allow both to be set in config.

## Motivation and Context

Trying to run a streaming job currently doesn't work because of this.

## Have you tested this? If so, how?
Unit tests pass and I tested this manually on a streaming job.

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change
- [ ] This PR has breaking change with big impact and a broad communication is done

## Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ". Please write it in the imperative.
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
