### PR TITLE
[cli,core,exec] removing v1 job_config parsing

### DIFF
--- a/cli/tests/commands/job/test_delete.py
+++ b/cli/tests/commands/job/test_delete.py
@@ -16,19 +16,22 @@ def config_data():
         "version": 1,
         "pipeline_options": {"project": "foo"},
         "job_config": {
-            "inputs": [
-                {
-                    "topic": "foo-topic",
-                    "subscription": "foo-sub",
-                    "data_location": "foo-input-location",
-                }
-            ],
-            "outputs": [
-                {
-                    "topic": "foo-topic-output",
-                    "data_location": "foo-output-location",
-                }
-            ],
+            "events": {
+                "inputs": [
+                    {
+                        "type": "pubsub",
+                        "topic": "foo-topic",
+                        "subscription": "foo-sub",
+                    }
+                ],
+                "outputs": [{"type": "pubsub", "topic": "foo-topic-output"}],
+            },
+            "data": {
+                "inputs": [{"type": "gcs", "location": "foo-input-location"}],
+                "outputs": [
+                    {"type": "gcs", "location": "foo-output-location"}
+                ],
+            },
         },
     }
 

--- a/cli/tests/commands/message/test_publish.py
+++ b/cli/tests/commands/message/test_publish.py
@@ -29,19 +29,24 @@ def klio_job_config():
         "version": 1,
         "pipeline_options": {"project": "test-gcp-project"},
         "job_config": {
-            "inputs": [
-                {
-                    "topic": "an-input-topic",
-                    "data_location": "gs://a-test-input/location",
-                    "subscription": "a-subscription",
-                }
-            ],
-            "outputs": [
-                {
-                    "topic": "foo-topic-output",
-                    "data_location": "foo-output-location",
-                }
-            ],
+            "events": {
+                "inputs": [
+                    {
+                        "type": "pubsub",
+                        "topic": "an-input-topic",
+                        "subscription": "a-subscription",
+                    }
+                ],
+                "outputs": [{"type": "pubsub", "topic": "foo-topic-output"}],
+            },
+            "data": {
+                "inputs": [
+                    {"type": "gcs", "location": "gs://a-test-input/location"}
+                ],
+                "outputs": [
+                    {"type": "gcs", "location": "foo-output-location"}
+                ],
+            },
         },
     }
     return config.KlioConfig(conf)

--- a/core/src/klio_core/config/_io.py
+++ b/core/src/klio_core/config/_io.py
@@ -456,18 +456,3 @@ class KlioGCSOutputDataConfig(KlioDataIOConfig, KlioGCSConfig):
     def from_dict(cls, config_dict, *args, **kwargs):
         config_dict = super()._from_dict(config_dict)
         return super().from_dict(config_dict, *args, **kwargs)
-
-
-# legacy config for v1
-@attr.attrs(frozen=True)
-class KlioJobInput(object):
-    topic = attr.attrib(type=str)
-    subscription = attr.attrib(type=str)
-    data_location = attr.attrib(type=str)
-
-
-# legacy config for v1
-@attr.attrs(frozen=True)
-class KlioJobOutput(object):
-    topic = attr.attrib(type=str)
-    data_location = attr.attrib(type=str)

--- a/exec/tests/unit/commands/test_run.py
+++ b/exec/tests/unit/commands/test_run.py
@@ -76,6 +76,7 @@ def _config():
     mock_config.job_name = "my-job"
     mock_output = mock.Mock()
     mock_output.topic = "my-topic"
+    mock_config.version = 2
 
     mock_input = mock.Mock()
     mock_input.subscription = "my-subscription"


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description

This removes basically all v1 parsing for `KlioConfig`, including the old `KlioJobInput/Output` and the `inputs/outputs` attributes.

This doesn't touch the config version checking logic in some of the transforms.

There were also some unrelated tests in `exec/tests/unit/test_cli` that were failing in master due to decorators being evaluated on import, I applied the same mocking patch used in other tests.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
All unit tests should be passing

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change
- [ ] This PR has breaking change with big impact and a broad communication is done

## Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ". Please write it in the imperative.
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
