### PR TITLE
[cli,core] pinning google-api-core to <= 1.16.0

### DIFF
--- a/cli/setup.py
+++ b/cli/setup.py
@@ -66,7 +66,7 @@ INSTALL_REQUIRES = [
     "emoji",
     "jinja2",
     "glom",
-    "google-api-core",
+    "google-api-core<=1.16.0",
     "google-api-python-client",
     "google-cloud-monitoring",
     # API breaking change w google-api-core

--- a/core/setup.py
+++ b/core/setup.py
@@ -62,7 +62,7 @@ META_FILE = read(META_PATH)
 INSTALL_REQUIRES = [
     "glom",
     "google-api-python-client",
-    "google-api-core",  # TODO: try and remove
+    "google-api-core<=1.16.0",  # TODO: try and remove
     "google-cloud-pubsub<=1.4.0",  # TODO: try and remove
     "protobuf",
     "pyyaml",


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description

This seems to be necessary to get things working.  Without this I'm running into:

```
File "/usr/local/lib/python3.6/site-packages/klio_core/utils.py", line 10, in <module>
    from google.cloud import pubsub
  File "/usr/local/lib/python3.6/site-packages/google/cloud/pubsub.py", line 20, in <module>
    from google.cloud.pubsub_v1 import PublisherClient
  File "/usr/local/lib/python3.6/site-packages/google/cloud/pubsub_v1/__init__.py", line 18, in <module>
    from google.cloud.pubsub_v1 import publisher
  File "/usr/local/lib/python3.6/site-packages/google/cloud/pubsub_v1/publisher/__init__.py", line 17, in <module>
    from google.cloud.pubsub_v1.publisher.client import Client
  File "/usr/local/lib/python3.6/site-packages/google/cloud/pubsub_v1/publisher/client.py", line 29, in <module>
    from google.cloud.pubsub_v1.gapic import publisher_client
  File "/usr/local/lib/python3.6/site-packages/google/cloud/pubsub_v1/gapic/publisher_client.py", line 75, in <module>
    class PublisherClient(object):
  File "/usr/local/lib/python3.6/site-packages/google/cloud/pubsub_v1/gapic/publisher_client.py", line 245, in PublisherClient
    retry=google.api_core.gapic_v1.method.DEFAULT,
AttributeError: module 'google.api_core' has no attribute 'gapic_v1'
```

## Motivation and Context
Trying to run a real job, either on direct-runner or dataflow, fails to startup with the above error.

## Have you tested this? If so, how?
Before fix: job would fail.  After fix: job starts up with no issue.

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change
- [ ] This PR has breaking change with big impact and a broad communication is done

## Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ". Please write it in the imperative.
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
