### PR TITLE
[cli,core,exec,lib] changing job_config IO fields to sub-objects

### DIFF
--- a/audio/src/klio_audio/decorators.py
+++ b/audio/src/klio_audio/decorators.py
@@ -199,7 +199,7 @@ def handle_binary(*decorator_args, **decorator_kwargs):
         def process(self, item):
             self._klio.logger.info(f"Downloading {item.element}")
             filename = item.payload.decode("utf-8")
-            location = self._klio.config.job_config.data_inputs[0].location
+            location = self._klio.config.job_config.data.inputs[0].location
             source_path = os.path.join(location, filename)
             with self.client.open(source_path, "rb") as source:
                 out = io.BytesIO(source.read())

--- a/audio/src/klio_audio/transforms/io.py
+++ b/audio/src/klio_audio/transforms/io.py
@@ -28,7 +28,7 @@ class GcsLoadBinary(_base.KlioAudioBaseDoFn):
     @decorators.handle_binary(skip_load=True)
     def process(self, item):
         element = item.element.decode("utf-8")
-        input_data = self._klio.config.job_config.data_inputs[0]
+        input_data = self._klio.config.job_config.data.inputs[0]
         file_suffix = input_data.file_suffix
         if not file_suffix.startswith("."):
             file_suffix = "." + file_suffix
@@ -70,7 +70,7 @@ class GcsUploadPlot(_base.KlioAudioBaseDoFn):
     @decorators.handle_binary(skip_dump=True)
     def process(self, item):
         element = item.element.decode("utf-8")
-        output_data = self._klio.config.job_config.data_outputs[0]
+        output_data = self._klio.config.job_config.data.outputs[0]
         file_suffix = output_data.file_suffix
         if not file_suffix.startswith("."):
             file_suffix = "." + file_suffix

--- a/cli/src/klio_cli/commands/job/delete.py
+++ b/cli/src/klio_cli/commands/job/delete.py
@@ -53,8 +53,8 @@ class DeleteJob(object):
         }
         to_delete["stackdriver_group"] = False
 
-        ev_inputs = self._job_config.event_inputs
-        ev_outputs = self._job_config.event_outputs
+        ev_inputs = self._job_config.events.inputs
+        ev_outputs = self._job_config.events.outputs
         for resource in ev_inputs + ev_outputs:
             if "pubsub" == resource.name:
                 if self._confirmation_dialog("topic", resource.topic):
@@ -67,8 +67,8 @@ class DeleteJob(object):
                 ):
                     to_delete["subscription"].append(resource.subscription)
 
-        data_inputs = self._job_config.data_inputs
-        data_outputs = self._job_config.data_outputs
+        data_inputs = self._job_config.data.inputs
+        data_outputs = self._job_config.data.outputs
         for resource in data_inputs + data_outputs:
             if "gcs" == resource.name:
                 if self._confirmation_dialog("location", resource.location):

--- a/cli/src/klio_cli/commands/job/verify.py
+++ b/cli/src/klio_cli/commands/job/verify.py
@@ -222,7 +222,7 @@ class VerifyJob(object):
         unverified_topic_count = 0
         unverified_sub_count = 0
 
-        data_inputs = self.klio_config.job_config.data_inputs
+        data_inputs = self.klio_config.job_config.data.inputs
 
         if not data_inputs:
             logging.warning("Your job has no data inputs, is that expected?")
@@ -240,7 +240,7 @@ class VerifyJob(object):
                 message = "There is no data_location for {}".format(_input)
                 logging.error(message)
 
-        event_inputs = self.klio_config.job_config.event_inputs
+        event_inputs = self.klio_config.job_config.events.inputs
 
         if not event_inputs:
             logging.warning("Your job has no event inputs, is that expected?")
@@ -291,7 +291,7 @@ class VerifyJob(object):
         unverified_bucket_count = 0
         unverified_topic_count = 0
 
-        data_outputs = self.klio_config.job_config.data_outputs
+        data_outputs = self.klio_config.job_config.data.outputs
 
         logging.info("Verifying your data outputs...")
 
@@ -307,7 +307,7 @@ class VerifyJob(object):
                     "There is no data_location for {}".format(output)
                 )
 
-        event_outputs = self.klio_config.job_config.event_outputs
+        event_outputs = self.klio_config.job_config.events.outputs
 
         logging.info("Verifying your event outputs...")
 

--- a/cli/src/klio_cli/commands/message/publish.py
+++ b/cli/src/klio_cli/commands/message/publish.py
@@ -36,7 +36,7 @@ def _get_current_klio_job(config):
     klio_job.job_name = config.job_name
     klio_job.gcp_project = config.pipeline_options.project
 
-    inputs = config.job_config.event_inputs
+    inputs = config.job_config.events.inputs
     for input_ in inputs:
         job_input = klio_job.JobInput()
         job_input.topic = input_.topic
@@ -44,7 +44,7 @@ def _get_current_klio_job(config):
             job_input.subscription = input_.subscription
         # [batch dev] TODO: hardcoding mapping between data and event
         # inputs for now (same behavior as v1)
-        job_input.data_location = config.job_config.data_inputs[0].location
+        job_input.data_location = config.job_config.data.inputs[0].location
         klio_job.inputs.extend([job_input])
 
     return klio_job
@@ -72,7 +72,7 @@ def _publish_messages(
     config, entity_ids, ping, force, top_down, allow_non_klio, msg_version
 ):
     current_job = _get_current_klio_job(config)
-    publish = _create_publisher(config.job_config.event_inputs[0].topic)
+    publish = _create_publisher(config.job_config.events.inputs[0].topic)
 
     success_ids = []
     fail_ids = []
@@ -116,7 +116,7 @@ def publish_messages(
     if msg_version is None:
         msg_version = config.version
 
-    if not config.job_config.event_inputs:
+    if not config.job_config.events.inputs:
         msg = "No input topics configured for {} :-1:".format(config.job_name)
         logging.error(emoji.emojize(msg, use_aliases=True))
         raise SystemExit(1)
@@ -126,7 +126,7 @@ def publish_messages(
             len(entity_ids),
             config.job_name,
             # [batch dev] should we support multiple inputs in the future?
-            config.job_config.event_inputs[0].topic,
+            config.job_config.events.inputs[0].topic,
         )
     )
     success, fail = _publish_messages(

--- a/cli/tests/commands/job/test_verify.py
+++ b/cli/tests/commands/job/test_verify.py
@@ -555,7 +555,7 @@ def test_verify_inputs(
         "io_type": kconfig._io.KlioIOType.EVENT,
         "io_direction": kconfig._io.KlioIODirection.INPUT,
     }
-    job.klio_config.job_config.event_inputs = [
+    job.klio_config.job_config.events.inputs = [
         kconfig._io.KlioPubSubEventInput.from_dict(event_config)
     ]
 
@@ -565,7 +565,7 @@ def test_verify_inputs(
         "io_type": kconfig._io.KlioIOType.DATA,
         "io_direction": kconfig._io.KlioIODirection.INPUT,
     }
-    job.klio_config.job_config.data_inputs = [
+    job.klio_config.job_config.data.inputs = [
         kconfig._io.KlioGCSInputDataConfig.from_dict(data_config)
     ]
 
@@ -644,21 +644,21 @@ def test_verify_inputs_logs(
         event_dict["type"] = "pubsub"
         event_dict["io_type"] = kconfig._io.KlioIOType.EVENT
         event_dict["io_direction"] = kconfig._io.KlioIODirection.OUTPUT
-        job.klio_config.job_config.event_inputs = [
+        job.klio_config.job_config.events.inputs = [
             kconfig._io.KlioPubSubEventInput.from_dict(event_dict)
         ]
     else:
-        job.klio_config.job_config.event_inputs = []
+        job.klio_config.job_config.events.inputs = []
 
     if data_dict:
         data_dict["type"] = "gcs"
         data_dict["io_type"] = kconfig._io.KlioIOType.DATA
         data_dict["io_direction"] = kconfig._io.KlioIODirection.OUTPUT
-        job.klio_config.job_config.data_inputs = [
+        job.klio_config.job_config.data.inputs = [
             kconfig._io.KlioGCSOutputDataConfig.from_dict(data_dict)
         ]
     else:
-        job.klio_config.job_config.data_inputs = []
+        job.klio_config.job_config.data.inputs = []
 
     job._verify_inputs()
     assert expected_log_count == len(caplog.records)
@@ -692,7 +692,7 @@ def test_verify_outputs(
         "io_type": kconfig._io.KlioIOType.EVENT,
         "io_direction": kconfig._io.KlioIODirection.OUTPUT,
     }
-    job.klio_config.job_config.event_outputs = [
+    job.klio_config.job_config.events.outputs = [
         kconfig._io.KlioPubSubEventOutput.from_dict(event_config)
     ]
 
@@ -702,7 +702,7 @@ def test_verify_outputs(
         "io_type": kconfig._io.KlioIOType.DATA,
         "io_direction": kconfig._io.KlioIODirection.OUTPUT,
     }
-    job.klio_config.job_config.data_outputs = [
+    job.klio_config.job_config.data.outputs = [
         kconfig._io.KlioGCSOutputDataConfig.from_dict(data_config)
     ]
 
@@ -771,7 +771,7 @@ def test_verify_outputs_logs(
         "io_type": kconfig._io.KlioIOType.EVENT,
         "io_direction": kconfig._io.KlioIODirection.OUTPUT,
     }
-    job.klio_config.job_config.event_outputs = [
+    job.klio_config.job_config.events.outputs = [
         kconfig._io.KlioPubSubEventOutput.from_dict(event_config)
     ]
 
@@ -781,7 +781,7 @@ def test_verify_outputs_logs(
         "io_type": kconfig._io.KlioIOType.DATA,
         "io_direction": kconfig._io.KlioIODirection.OUTPUT,
     }
-    job.klio_config.job_config.data_outputs = [
+    job.klio_config.job_config.data.outputs = [
         kconfig._io.KlioGCSOutputDataConfig.from_dict(data_config)
     ]
 

--- a/cli/tests/commands/message/test_publish.py
+++ b/cli/tests/commands/message/test_publish.py
@@ -252,7 +252,7 @@ def test_publish_messages_fails(
 
 
 def test_publish_messages_raises(klio_job_config, monkeypatch, caplog):
-    monkeypatch.setattr(klio_job_config.job_config, "event_inputs", None)
+    monkeypatch.setattr(klio_job_config.job_config.events, "inputs", None)
 
     with pytest.raises(SystemExit):
         publish.publish_messages(klio_job_config, ["s0m3-ent1ty-1D"])

--- a/core/src/klio_core/config/_io.py
+++ b/core/src/klio_core/config/_io.py
@@ -93,7 +93,7 @@ class KlioIOConfig(object):
 
         Useful for instantiating objects where the config keys map 1:1
         to the object init arguments/keyword arguments, i.e.
-        KlioReadFromBigQuery(**config.job_config.event_inputs[0].as_dict())
+        KlioReadFromBigQuery(**config.job_config.events.inputs[0].as_dict())
         """
         # filter parameter is used as "to include"/"filter-in",
         # not "to exclude"/"filter-out"

--- a/core/src/klio_core/config/core.py
+++ b/core/src/klio_core/config/core.py
@@ -64,6 +64,12 @@ class KlioConfig(BaseKlioConfig):
     pass
 
 
+@attr.attrs
+class KlioIOConfigContainer(object):
+    inputs = attr.attrib()
+    outputs = attr.attrib()
+
+
 @utils.config_object(key_prefix="job_config", allow_unknown_keys=True)
 class KlioJobConfig(object):
     """Job-specific config representing the "job_config" key of klio-job.yaml.
@@ -120,25 +126,32 @@ class KlioJobConfig(object):
                 self.USER_ATTRIBS.append({key: value})
 
     def _parse_io(self, config_dict):
-        self.event_inputs = self._create_config_objects(
+        event_inputs = self._create_config_objects(
             config_dict.get("events", {}).get("inputs", []),
             io.KlioIOType.EVENT,
             io.KlioIODirection.INPUT,
         )
-        self.event_outputs = self._create_config_objects(
+        event_outputs = self._create_config_objects(
             config_dict.get("events", {}).get("outputs", []),
             io.KlioIOType.EVENT,
             io.KlioIODirection.OUTPUT,
         )
-        self.data_inputs = self._create_config_objects(
+        self.events = KlioIOConfigContainer(
+            inputs=event_inputs, outputs=event_outputs
+        )
+
+        data_inputs = self._create_config_objects(
             config_dict.get("data", {}).get("inputs", []),
             io.KlioIOType.DATA,
             io.KlioIODirection.INPUT,
         )
-        self.data_outputs = self._create_config_objects(
+        data_outputs = self._create_config_objects(
             config_dict.get("data", {}).get("outputs", []),
             io.KlioIOType.DATA,
             io.KlioIODirection.OUTPUT,
+        )
+        self.data = KlioIOConfigContainer(
+            inputs=data_inputs, outputs=data_outputs
         )
 
     def _get_all_config_subclasses(self):
@@ -187,18 +200,18 @@ class KlioJobConfig(object):
         )
         config_dict["events"] = {}
         config_dict["events"]["inputs"] = [
-            ei.as_dict() for ei in self.event_inputs
+            ei.as_dict() for ei in self.events.inputs
         ]
         config_dict["events"]["outputs"] = [
-            eo.as_dict() for eo in self.event_outputs
+            eo.as_dict() for eo in self.events.outputs
         ]
 
         config_dict["data"] = {}
         config_dict["data"]["inputs"] = [
-            di.as_dict() for di in self.data_inputs
+            di.as_dict() for di in self.data.inputs
         ]
         config_dict["data"]["outputs"] = [
-            do.as_dict() for do in self.data_outputs
+            do.as_dict() for do in self.data.outputs
         ]
         return config_dict
 

--- a/core/tests/config/test_config.py
+++ b/core/tests/config/test_config.py
@@ -281,14 +281,14 @@ def test_klio_job_config(
     assert timeout_threshold == config_obj.timeout_threshold
     assert 3 == config_obj.number_of_retries
 
-    ret_input_topics = [i.topic for i in config_obj.event_inputs]
-    ret_output_topics = [o.topic for o in config_obj.event_outputs]
+    ret_input_topics = [i.topic for i in config_obj.events.inputs]
+    ret_output_topics = [o.topic for o in config_obj.events.outputs]
 
     assert ["test-parent-job-out"] == ret_input_topics
     assert ["test-job-out"] == ret_output_topics
 
-    ret_input_data = [i.location for i in config_obj.data_inputs]
-    ret_output_data = [o.location for o in config_obj.data_outputs]
+    ret_input_data = [i.location for i in config_obj.data.inputs]
+    ret_output_data = [o.location for o in config_obj.data.outputs]
 
     assert ["gs://sigint-output/test-parent-job-out"] == ret_input_data
     assert ["gs://sigint-output/test-job-out"] == ret_output_data

--- a/exec/src/klio_exec/commands/run.py
+++ b/exec/src/klio_exec/commands/run.py
@@ -67,15 +67,15 @@ class KlioPipeline(object):
 
     @property
     def _has_event_inputs(self):
-        return len(self.config.job_config.event_inputs) > 0
+        return len(self.config.job_config.events.inputs) > 0
 
     @property
     def _has_multi_event_inputs(self):
-        return len(self.config.job_config.event_inputs) > 1
+        return len(self.config.job_config.events.inputs) > 1
 
     @property
     def _has_event_outputs(self):
-        return len(self.config.job_config.event_outputs) > 0
+        return len(self.config.job_config.events.outputs) > 0
 
     @property
     def _io_mapper(self):
@@ -243,16 +243,16 @@ class KlioPipeline(object):
         # label prefixes are required for multiple inputs (to avoid label
         # name collisions in Beam)
         if (
-            len(self.config.job_config.data_inputs) > 1
-            or len(self.config.job_config.data_outputs) > 1
+            len(self.config.job_config.data.inputs) > 1
+            or len(self.config.job_config.data.outputs) > 1
         ):
             logging.error(
                 "Klio does not (yet) support multiple data inputs and outputs."
             )
             raise SystemExit(1)
 
-        data_input_config = self.config.job_config.data_inputs[0]
-        data_output_config = self.config.job_config.data_outputs[0]
+        data_input_config = self.config.job_config.data.inputs[0]
+        data_output_config = self.config.job_config.data.outputs[0]
 
         pfx = ""
         if label_prefix is not None:
@@ -310,7 +310,7 @@ class KlioPipeline(object):
     # TODO this can prob go away if/when we make event_inputs a
     # dictionary rather than a list of dicts (@lynn)
     def _generate_input_conf_names(self):
-        ev_inputs = self.config.job_config.event_inputs
+        ev_inputs = self.config.job_config.events.inputs
         input_dict = {}
         for index, ev in enumerate(ev_inputs):
             name = "{}{}".format(ev.name, index)
@@ -368,7 +368,7 @@ class KlioPipeline(object):
         # sanity check - I think klio config forces event input
         if self._has_event_inputs:
             if not self._has_multi_event_inputs:
-                input_config = self.config.job_config.event_inputs[0]
+                input_config = self.config.job_config.events.inputs[0]
                 to_process, to_pass_thru = self._generate_pcoll(
                     pipeline, input_config
                 )
@@ -380,7 +380,7 @@ class KlioPipeline(object):
         out_pcol = run_callable(to_process, self.config)
 
         if self._has_event_outputs:
-            output_config = self.config.job_config.event_outputs[0]
+            output_config = self.config.job_config.events.outputs[0]
             if not output_config.skip_klio_write:
                 transform_cls_out = self._io_mapper.output[output_config.name]
                 to_output = out_pcol

--- a/exec/tests/unit/commands/test_run.py
+++ b/exec/tests/unit/commands/test_run.py
@@ -92,10 +92,10 @@ def _config():
         "location": "gs://sigint/",
     }
     mock_job_config = mock.Mock()
-    mock_job_config.event_inputs = [mock_input]
-    mock_job_config.event_outputs = [mock_output]
-    mock_job_config.data_inputs = [mock_input]
-    mock_job_config.data_outputs = [mock_output]
+    mock_job_config.events.inputs = [mock_input]
+    mock_job_config.events.outputs = [mock_output]
+    mock_job_config.data.inputs = [mock_input]
+    mock_job_config.data.outputs = [mock_output]
 
     mock_pipeline_options = mock.Mock()
 
@@ -652,8 +652,8 @@ def test_run_pipeline(
         mock_output.to_io_kwargs.return_value = {
             "topic": "projects/foo/topics/bar",
         }
-        config.job_config.event_inputs = [mock_input]
-        config.job_config.event_outputs = [mock_output]
+        config.job_config.events.inputs = [mock_input]
+        config.job_config.events.outputs = [mock_output]
 
     if run_error:
         mock_pipeline.return_value.run.side_effect = [

--- a/lib/src/klio/transforms/_helpers.py
+++ b/lib/src/klio/transforms/_helpers.py
@@ -144,7 +144,7 @@ class _KlioInputDataMixin(object):
     @property
     def _data_config(self):
         # TODO: figure out how to support multiple inputs
-        return self._klio.config.job_config.data_inputs[0]
+        return self._klio.config.job_config.data.inputs[0]
 
 
 class _KlioOutputDataMixin(object):
@@ -158,7 +158,7 @@ class _KlioOutputDataMixin(object):
     @property
     def _data_config(self):
         # TODO: figure out how to support multiple outputs
-        return self._klio.config.job_config.data_outputs[0]
+        return self._klio.config.job_config.data.outputs[0]
 
 
 class _KlioGcsDataExistsMixin(object):

--- a/lib/src/klio/transforms/core.py
+++ b/lib/src/klio/transforms/core.py
@@ -51,7 +51,7 @@ class _KlioNamespace(object):
         klio_job.job_name = self.config.job_name
         klio_job.gcp_project = self.config.pipeline_options.project
 
-        inputs = self.config.job_config.event_inputs
+        inputs = self.config.job_config.events.inputs
         # [batch dev] we're essentially zipping together event inputs with
         #             data inputs. not sure if this is a good assumption
         # [batch dev] TODO: this should be updated once we update the proto
@@ -63,7 +63,7 @@ class _KlioNamespace(object):
                 job_input.topic = input_.topic
                 job_input.subscription = input_.subscription
 
-            data_input = self.config.job_config.data_inputs[index]
+            data_input = self.config.job_config.data.inputs[index]
             if data_input and data_input.name == "gcs":
                 job_input.data_location = data_input.location
             klio_job.inputs.extend([job_input])
@@ -340,7 +340,7 @@ class KlioContext(object):
         klio_job.job_name = self.config.job_name
         klio_job.gcp_project = self.config.pipeline_options.project
 
-        inputs = self.config.job_config.event_inputs
+        inputs = self.config.job_config.events.inputs
         # [batch dev] we're essentially zipping together event inputs with
         #             data inputs. not sure if this is a good assumption
         # [batch dev] TODO: this should be updated once we update the proto
@@ -352,7 +352,7 @@ class KlioContext(object):
                 job_input.topic = input_.topic
                 job_input.subscription = input_.subscription
 
-            data_input = self.config.job_config.data_inputs[index]
+            data_input = self.config.job_config.data.inputs[index]
             if data_input and data_input.name == "gcs":
                 job_input.data_location = data_input.location
             klio_job.inputs.extend([job_input])

--- a/lib/src/klio/transforms/helpers.py
+++ b/lib/src/klio/transforms/helpers.py
@@ -97,7 +97,7 @@ class KlioWriteToEventOutput(beam.PTransform):
     @decorators._set_klio_context
     def _event_config(self):
         # TODO: figure out how to support multiple outputs
-        return self._klio.config.job_config.event_outputs[0]
+        return self._klio.config.job_config.events.outputs[0]
 
     def expand(self, pcoll):
         transform_kls = self.CONFNAME_TO_OUT_TRANSFORM[self._event_config.name]


### PR DESCRIPTION
# Hey, I just made a Pull Request!


## Description

event/data inputs/outputs in `job_config` have been converted to sub-objects.

**Before**
```python
my_data_input = klio_config.job_config.event_inputs[0]
```

**Now**
```python
my_data_input = klio_config.job_config.events.inputs[0]
```

...and similarly for `event_outputs`, `data_inputs`, and `data_outputs`

# VERY IMPORTANT DILEMMA BEFORE MERGING

right now I have converted `event_inputs` to `events.inputs`, using the plural "events" instead of "event".  Although this means it's a slightly more involved change from just converting '_' to '.', it sounds more natural and more-importantly lines up with the fields in the yaml config.

So we need to either decide to go with `.events` or stick with `event`, but that should also mean we change it in the yaml.

My vote is obviously on `events` since that's how the PR is right now, but open to objections.

## Motivation and Context
We want the `KlioConfig` object's structure to line up with the structure of the YAML file, which has nested objects for I/O.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or -->
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [x] All tests pass
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change
- [ ] This PR has breaking change with big impact and a broad communication is done

## Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ". Please write it in the imperative.
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
