### PR TITLE
[cli] pin google-cloud-storage < 1.30.0

### DIFF
--- a/cli/setup.py
+++ b/cli/setup.py
@@ -71,7 +71,7 @@ INSTALL_REQUIRES = [
     "google-cloud-monitoring",
     # API breaking change w google-api-core
     "google-cloud-pubsub<=1.4.0",
-    "google-cloud-storage",
+    "google-cloud-storage<1.30.0",
     # API breaking change w google-cloud-monitoring
     "googleapis-common-protos<1.50.0",
     "klio-core",


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
This is needed, otherwise we get errors like:

```
ERROR: google-cloud-core 1.4.1 has requirement google-api-core<2.0.0dev,>=1.19.0, but you'll have google-api-core 1.16.0 which is incompatible.
```


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or -->
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change
- [ ] This PR has breaking change with big impact and a broad communication is done

## Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ". Please write it in the imperative.
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
