### PR TITLE
[cli, core] remove deprecated config keys

### DIFF
--- a/cli/tests/commands/job/test_stop.py
+++ b/cli/tests/commands/job/test_stop.py
@@ -300,7 +300,9 @@ def test_stop(mocker, monkeypatch, mock_discovery_client, job, stop_job_inst):
     mock_watch_job_state.assert_called_once_with(job)
 
 
-def test_stop_no_running_job(mocker, monkeypatch, mock_discovery_client, stop_job_inst, job):
+def test_stop_no_running_job(
+    mocker, monkeypatch, mock_discovery_client, stop_job_inst, job
+):
     mock_set_dataflow_client = mocker.Mock()
     monkeypatch.setattr(
         stop_job_inst, "_set_dataflow_client", mock_set_dataflow_client

--- a/core/src/klio_core/config/core.py
+++ b/core/src/klio_core/config/core.py
@@ -5,7 +5,6 @@
 from __future__ import absolute_import
 
 import logging
-import multiprocessing
 
 import attr
 
@@ -90,15 +89,8 @@ class KlioJobConfig(object):
     version = utils.field(type=int)
 
     # optional attributes
-    timeout_threshold = utils.field(type=int, default=0)
-    thread_pool_processes = utils.field(
-        type=int, default=multiprocessing.cpu_count() - 1
-    )
-    number_of_retries = utils.field(type=int, default=0)
     allow_non_klio_messages = utils.field(type=bool, default=False)
-    binary_non_klio_messages = utils.field(type=bool, default=False)
     metrics = utils.field(default={})
-    dependencies = utils.field(default=[])
     blocking = utils.field(type=bool, default=False)
 
     def __config_post_init__(self, config_dict):

--- a/lib/tests/unit/conftest.py
+++ b/lib/tests/unit/conftest.py
@@ -21,7 +21,6 @@ def job_config_dict():
     return {
         "metrics": {"logger": {}},
         "allow_non_klio_messages": False,
-        "timeout_threshold": 30,
         "number_of_retries": 3,
         "inputs": [
             {


### PR DESCRIPTION
Removes a bunch of config keys that are no longer used in v2.  The most significant being `job_config.dependencies` since it also involved removing one of the checks in `verify`.

(~~I will probably squash the commits together before merging~~ and I already did...)

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ ] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
