### PR TITLE
[CI] Fix manual workflow

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -12,10 +12,6 @@ on:
         required: true
         default: 'cli'
 
-defaults:
-  run:
-    working-directory: ${{ github.event.inputs.package }}
-
 jobs:
   tests:
     name: "${{ github.event.inputs.package }}: py${{ github.event.inputs.python-version }} (ubuntu)"
@@ -34,3 +30,4 @@ jobs:
           python -m pip install --upgrade virtualenv tox tox-gh-actions
       - name: "Run tox for ${{ github.event.inputs.package }} on ${{ github.event.inputs.python-version }}"
         run: "python -m tox -c tox.ini"
+        working-directory: ${{ github.event.inputs.package }}


### PR DESCRIPTION
<!--- Describe your changes 

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

Manual trigger of a workflow seems to be b0rked, I suspect because the `github` variable namespace is not yet available when it is parsing defaults (some [docs](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/) on manual triggering).

<!--- How have you tested this?
Some valid responses are:

* "I have included unit tests" 
* "I have included integration tests"
* "I successfully ran my jobs with this code"

-->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ ] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
