### PR TITLE
[core] add basic config preprocessing hook

### DIFF
--- a/cli/src/klio_cli/commands/job/configuration.py
+++ b/cli/src/klio_cli/commands/job/configuration.py
@@ -43,6 +43,10 @@ class EffectiveJobConfig(object):
         conf = kconfig.KlioConfig(self.config_data)
 
         effective_config = conf.as_dict()
+        return self._order_config_keys(effective_config)
+
+    @staticmethod
+    def _order_config_keys(effective_config):
         key_order = ["version", "job_name", "pipeline_options", "job_config"]
         all_keys = list(effective_config.keys())
         other_top_level_keys = [k for k in all_keys if k not in key_order]

--- a/core/src/klio_core/config/_preprocessing.py
+++ b/core/src/klio_core/config/_preprocessing.py
@@ -18,6 +18,21 @@ class KlioConfigPreprocessor(object):
     """This handles everything between parsing the config from YAML and passing
     the parsed dict to KlioConfig."""
 
+    # list of lambdas
+    PLUGIN_PREPROCESSORS = []
+
+    @classmethod
+    def add_plugin_preprocessor(cls, proc):
+        """proc should be a function that accepts the config_dict as a
+        parameter and returns a modified version of it"""
+        cls.PLUGIN_PREPROCESSORS.append(proc)
+
+    @classmethod
+    def _apply_plugin_preprocessors(cls, config_dict):
+        for pre_processor in cls.PLUGIN_PREPROCESSORS:
+            config_dict = pre_processor(config_dict)
+        return config_dict
+
     @staticmethod
     def _transform_io_list(io_subsection_list):
         """Transform lists of dicts into a nested dict of dicts, where the keys
@@ -215,6 +230,8 @@ class KlioConfigPreprocessor(object):
         )
 
         config_dict = yaml.safe_load(templated_config_data)
+
+        config_dict = cls._apply_plugin_preprocessors(config_dict)
 
         transformed_config = cls._transform_io_sections(config_dict)
         override_config = cls._apply_overrides(

--- a/core/tests/config/test_preprocessing.py
+++ b/core/tests/config/test_preprocessing.py
@@ -1,6 +1,7 @@
 import json
 
 import pytest
+import yaml
 
 from klio_core import exceptions
 from klio_core.config import _preprocessing
@@ -205,3 +206,26 @@ def test_apply_templates(
         new_dict = kcp._apply_templates(raw_config_str, template_dict)
         assert isinstance(new_dict, str)
         assert expected == json.loads(new_dict)
+
+
+def test_apply_plugin_preprocessing(mocker, kcp):
+
+    config = {
+        "version": 1,
+        "job_name": "test_job",
+        "job_config": {},
+    }
+    raw_config = yaml.dump(config)
+
+    def add_field(config_dict):
+        config_dict["version"] = 2
+        return config_dict
+
+    expected_config = config.copy()
+    expected_config["version"] = 2
+
+    mocker.patch.object(kcp, "PLUGIN_PREPROCESSORS", [add_field])
+
+    processed_config = kcp.process(raw_config, [], [])
+
+    assert expected_config == processed_config


### PR DESCRIPTION
This adds a very simple plugin system for config pre-processing, where functions can be added to do some transformation on the raw config dict before it is used to construct a `KlioConfig`.

Because the plugin is part of the `KlioConfigPreprocessor`, it will only be used in cli commands that use the `with_klio_config` decorator.  This should be ok for what we need it for anyway.

Also tried to make this as small of a change as possible since I don't think we will actually need this functionality for very long.

<!--- How have you tested this?
Some valid responses are:

* "I have included unit tests" 
* "I have included integration tests"
* "I successfully ran my jobs with this code"

-->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ ] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
