### PR TITLE
[cli]fix typo in dependency

### DIFF
--- a/cli/setup.py
+++ b/cli/setup.py
@@ -66,7 +66,7 @@ INSTALL_REQUIRES = [
     "emoji",
     "jinja2",
     "glom",
-    "google-api-core>1.18.0<1.21.0",
+    "google-api-core>1.18.0,<1.21.0",
     "google-api-python-client>=1.10.0",
     "google-cloud-monitoring",
     # API breaking change w google-api-core


### PR DESCRIPTION
just missing a comma.  I believe the github action didn't catch anything since it manually installs `core` first which doesn't have the typo.  But I ran into this myself when installing just `klio_cli`.  It's possible we might want to change how the action works, but keeping this PR simple for now.

<!--- How have you tested this?
Some valid responses are:

* "I have included unit tests" 
* "I have included integration tests"
* "I successfully ran my jobs with this code"

-->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ ] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
