### PR TITLE
[lib, docs] Add a retry decorator

### DIFF
--- a/docs/src/reference/lib/api/decorators.rst
+++ b/docs/src/reference/lib/api/decorators.rst
@@ -5,6 +5,7 @@ Decorators
 
 .. autodecorator:: handle_klio()
 .. autodecorator:: timeout(seconds, exception=None, exception_message=None)
+.. autodecorator:: retry(tries=-1, delay=0, exception=None, raise_exception=None, exception_message=None)
 .. autodecorator:: set_klio_context()
 .. autodecorator:: inject_klio_context()
 .. autodecorator:: serialize_klio_message()

--- a/docs/src/reference/lib/api/index.rst
+++ b/docs/src/reference/lib/api/index.rst
@@ -24,6 +24,7 @@ Decorators
 
     decorators.handle_klio
     decorators.timeout
+    decorators.retry
     decorators.set_klio_context
     decorators.inject_klio_context
     decorators.serialize_klio_message

--- a/docs/src/userguide/pipeline/index.rst
+++ b/docs/src/userguide/pipeline/index.rst
@@ -111,6 +111,7 @@ then used then decorating methods on transforms to make use of functionalities s
  * :ref:`De/serialization of Klio Messages <serialization-klio-message>`
  * :ref:`Inject klio context on methods and functions <accessing-klio-context>`
  * :ref:`Handle timeouts <timeout>`
+ * :ref:`Retry on failure <retries>`
 
 
 
@@ -161,6 +162,7 @@ Helper transforms available including the below.
  * :ref:`Data existence cheks <data-existence-checks>`
  * :ref:`Inject klio context on methods and functions <accessing-klio-context>`
  * :ref:`Handle timeouts <timeout>`
+ * :ref:`Retry on failure <retries>`
 
 
 

--- a/docs/src/userguide/pipeline/utilities.rst
+++ b/docs/src/userguide/pipeline/utilities.rst
@@ -166,8 +166,8 @@ function.
     method, see :ref:`@set_klio_context <set-klio-context>`. If KlioMessage de/serialization
     functionality is needed, see :ref:`@handle_klio <handle-klio>`.
 
-Timeouts
---------
+Handling Transient Errors
+-------------------------
 
 .. _timeout:
 
@@ -178,6 +178,19 @@ Timeouts
 with a timeout in a separate Python process. On timeout, the method or function will raise an
 exception of the provided type or default to raising a ``KlioTimeoutError``.
 
+.. caution::
+
+    If ``@timeout`` is being used with :ref:`@retry <retries>`, **order is important** depending
+    on the desired effect.
+
+    If ``@timeout`` is applied to a function before ``@retry``, then retries will apply first,
+    meaning the configured timeout will cancel the function even if the retries have not yet been
+    exhausted. In this case, be careful with the ``delay`` argument for the ``@retry`` decorator:
+    the set timeout is inclusive of a retry's delay.
+
+    Conversely, if ``@retry`` is applied to a function before ``@timeout``, retries will continue
+    until exhausted even if a function has timed out.
+
 .. code-block:: python
 
     from klio.transforms import decorators
@@ -190,7 +203,7 @@ exception of the provided type or default to raising a ``KlioTimeoutError``.
             )
 
 
-    @timeout(
+    @decorators.timeout(
         seconds=5,
         exception=MyTimeoutException,
         exception_message="I got a timeout!"
@@ -199,22 +212,107 @@ exception of the provided type or default to raising a ``KlioTimeoutError``.
         print(f"Received {item}!")
 
 
-If in use with another Klio decorator, the :func:`@timeout <klio.transforms.decorators.timeout>`
-decorator should be applied to a method or function **after** the other Klio decorator.
+.. caution::
+
+    If in use with another Klio decorator, the :func:`@timeout
+    <klio.transforms.decorators.timeout>` decorator should be applied to a method or function
+    **after** the other Klio decorator.
+
+    .. code-block:: python
+
+        from klio.transforms import decorators
+
+        @decorators.handle_klio
+        @decorators.timeout(seconds=5)
+        def my_map_func(ctx, item):
+            ctx.logger.info(f"Received {item.element} with {item.payload}")
+
+
+        class MyDoFn(beam.DoFn):
+            @decorators.handle_klio
+            @decorators.timeout(seconds=5, exception=MyTimeoutException)
+            def process(self, item):
+                self._klio.logger.info(
+                    f"Received {item.element} with {item.payload}"
+                )
+
+
+.. _retries:
+
+``@retry``
+^^^^^^^^^^
+
+:func:`@retry <klio.transforms.decorators.retry>` will retry the decorated method or function on
+failure. When retries are exhausted, ``KlioRetriesExhausted`` exception will be raised. Unless
+otherwise configured, a method or function decorated by ``@retry`` will be retried infinitely.
+
+.. caution::
+
+    If ``@retry`` is being used with :ref:`@timeout <timeout>`, **order is important** depending
+    on the desired effect.
+
+    If ``@timeout`` is applied to a function before ``@retry``, then retries will apply first,
+    meaning the configured timeout will cancel the function even if the retries have not yet been
+    exhausted. In this case, be careful with the ``delay`` argument for the ``@retry`` decorator:
+    the set timeout is inclusive of a retry's delay.
+
+    Conversely, if ``@retry``  is applied to a function before ``@timeout``, retries will continue
+    until exhausted even if a function has timed out.
+
 
 .. code-block:: python
 
     from klio.transforms import decorators
 
     @decorators.handle_klio
-    @decorators.timeout(seconds=5)
+    @decorators.retry()  # infinite retries, same as tries=-1
     def my_map_func(ctx, item):
         ctx.logger.info(f"Received {item.element} with {item.payload}")
+        ...
+
 
     class MyDoFn(beam.DoFn):
         @decorators.handle_klio
-        @decorators.timeout(seconds=5, exception=MyTimeoutException)
+        @decorators.retry(tries=3, exception=MyExceptionToCatch)
         def process(self, item):
-            self._klio.logger.info(
-                f"Received {item.element} with {item.payload}"
-            )
+            self._klio.logger.info(f"Received {item.element} with {item.payload}")
+            ...
+
+
+    # all available keyword arguments
+    @decorators.handle_klio
+    @decorators.retry(
+        tries=3,
+        delay=2.5,  # seconds
+        exception=MyExceptionToCatch,
+        raise_exception=MyExceptionToRaise,
+        exception_message="All retries have been exhausted!"
+    )
+    def my_other_map_function(item):
+        print(f"Received {item}!")
+        ...
+
+
+.. caution::
+
+    If in use with another Klio decorator, the :func:`@retry <klio.transforms.decorators.retry>`
+    decorator should be applied to a method or function **after** the other Klio decorator.
+
+    .. code-block:: python
+
+        from klio.transforms import decorators
+
+        @decorators.handle_klio
+        @decorators.retry(tries=5)
+        def my_map_func(ctx, item):
+            ctx.logger.info(f"Received {item.element} with {item.payload}")
+            ...
+
+
+        class MyDoFn(beam.DoFn):
+            @decorators.handle_klio
+            @decorators.retries(tries=5, exception=MyExceptionToCatch)
+            def process(self, item):
+                self._klio.logger.info(f"Received {item.element}")
+                ...
+

--- a/lib/src/klio/transforms/_retry.py
+++ b/lib/src/klio/transforms/_retry.py
@@ -1,0 +1,99 @@
+# Copyright 2020 Spotify AB
+"""
+This module is inspired by https://github.com/invl/retry
+and https://github.com/pnpnpn/retry-decorator.
+It's been simplified for what we need, and adapted to work with generators.
+"""
+
+import logging
+import threading
+import types
+
+
+TRACEBACK_HEADER = "Traceback (most recent call last):\n"
+
+
+class KlioRetriesExhausted(Exception):
+    """No more retries left."""
+
+
+class KlioRetryWrapper(object):
+    """Wrap a function with configured retries."""
+
+    DEFAULT_EXC_MSG = (
+        "Function '{}' has reached the maximum {} retries. Last exception: {}"
+    )
+
+    def __init__(
+        self,
+        function,
+        tries,
+        delay=None,
+        exception=None,
+        raise_exception=None,
+        exception_message=None,
+    ):
+        self._function = function
+        self._func_name = getattr(function, "__qualname__", function.__name__)
+        self._tries = tries
+        self._delay = delay or 0.0
+        self._exception = exception or Exception
+        self._retry_exception = raise_exception or KlioRetriesExhausted
+        self._exception_message = exception_message
+        self._logger = logging.getLogger("klio")
+
+    def __call__(self, *args, **kwargs):
+        tries = self._tries
+
+        while tries:
+            try:
+                ret = self._function(*args, **kwargs)
+                if isinstance(ret, types.GeneratorType):
+                    ret = next(ret)
+                return ret
+
+            except self._exception as e:
+                tries -= 1
+                if not tries:
+                    self._raise_exception(e)
+                    break
+
+                msg = self._format_log_message(tries, e)
+                self._logger.warning(msg)
+
+                if not self._delay > 0.0:
+                    continue
+
+                # use a Condition to avoid using `time.sleep` as that will
+                # block other threads; we just want to block this thread
+                condition = threading.Condition()
+                condition.acquire()
+                condition.wait(self._delay)
+                condition.release()
+
+    def _format_log_message(self, tries, exception):
+        msg_prefix = "Retrying KlioMessage"
+        if self._delay > 0:
+            msg_prefix = "{} in {} seconds".format(msg_prefix, self._delay)
+
+        attempts = self._tries - tries
+        msg_attempts = "attempt {}".format(attempts)
+        if self._tries > 0:
+            msg_attempts = "{} of {}".format(msg_attempts, self._tries)
+
+        msg = "{} - {}. '{}' raised an exception: {} ".format(
+            msg_prefix, msg_attempts, self._func_name, exception
+        )
+
+        return msg
+
+    def _raise_exception(self, last_exception):
+        if self._exception_message is None:
+            self._exception_message = self.DEFAULT_EXC_MSG.format(
+                self._func_name, self._tries, last_exception
+            )
+        error = self._retry_exception(self._exception_message)
+        self._logger.error(
+            "Dropping KlioMessage - retries exhausted: {}".format(error)
+        )
+        raise error

--- a/lib/tests/unit/transforms/test_decorators.py
+++ b/lib/tests/unit/transforms/test_decorators.py
@@ -1,0 +1,130 @@
+# Copyright 2020 Spotify AB
+
+from unittest import mock
+
+import pytest
+
+from klio_core.proto import klio_pb2
+
+from klio.transforms import decorators
+
+
+# The most helper transforms end up calling config attributes, so
+# we'll just patch the config for the whole test module and turn on
+# autouse
+@pytest.fixture(autouse=True, scope="module")
+def mock_config():
+    config = mock.Mock()
+    patcher = mock.patch(
+        "klio.transforms.core.KlioContext._load_config_from_file",
+        lambda x: config,
+    )
+    patcher.start()
+
+
+@pytest.fixture
+def kmsg():
+    msg = klio_pb2.KlioMessage()
+    msg.data.element = b"3l3m3nt"
+    return msg
+
+
+def test_retry(kmsg, mocker):
+    mock_function = mocker.Mock()
+
+    @decorators._handle_klio
+    @decorators._retry(tries=2)
+    def func(*args, **kwargs):
+        mock_function(*args, **kwargs)
+        raise Exception("fuu")
+
+    func(kmsg.SerializeToString())
+
+    assert 2 == mock_function.call_count
+
+
+def test_retry_custom_catch(kmsg, mocker):
+
+    # Assert retry on custom exception
+    class CustomCatchException(Exception):
+        pass
+
+    mock_function = mocker.Mock()
+    raise_custom = True
+
+    @decorators._handle_klio
+    @decorators._retry(tries=3, exception=CustomCatchException)
+    def func(*args, **kwargs):
+        mock_function(*args, **kwargs)
+        if raise_custom:
+            raise CustomCatchException("custom fuu")
+        raise Exception("fuu")
+
+    func(kmsg.SerializeToString())
+    assert 3 == mock_function.call_count
+
+    # Assert retry on multiple custom exceptions
+    class AnotherCustomCatchException(Exception):
+        pass
+
+    exc_tuple = (CustomCatchException, AnotherCustomCatchException)
+
+    @decorators._handle_klio
+    @decorators._retry(tries=3, exception=exc_tuple)
+    def func(*args, **kwargs):
+        mock_function(*args, **kwargs)
+        if raise_custom:
+            raise CustomCatchException("custom fuu")
+        raise Exception("fuu")
+
+    mock_function.reset_mock()
+    func(kmsg.SerializeToString())
+    assert 3 == mock_function.call_count
+
+    # Assert retries do not happen for an exception that isn't provided
+    mock_function.reset_mock()
+    raise_custom = False
+    func(kmsg.SerializeToString())
+    assert 1 == mock_function.call_count
+
+
+def test_retry_raises_runtime_parents(kmsg, mocker):
+    # Need to call @retry with parens
+    with pytest.raises(RuntimeError):
+
+        @decorators._handle_klio
+        @decorators.retry
+        def func(*args, **kwargs):
+            pass
+
+        func(kmsg.SerializeToString())
+
+
+@pytest.mark.parametrize(
+    "invalid_tries", (-2, 0.5, "1", {"a": "dict"}, ["a", "list"], lambda x: x)
+)
+def test_retry_raises_runtime_invalid_tries(invalid_tries, kmsg, mocker):
+    # Assert `tries` as a valid integer
+    with pytest.raises(RuntimeError):
+
+        @decorators._handle_klio
+        @decorators._retry(tries=invalid_tries)
+        def func(*args, **kwargs):
+            pass
+
+        func(kmsg.SerializeToString())
+
+
+@pytest.mark.parametrize(
+    "invalid_delay", (-2, {"a": "dict"}, ["a", "list"], lambda x: x)
+)
+def test_retry_raises_runtime_invalid_delay(invalid_delay, kmsg, mocker):
+    # Assert `delay` as a valid int/float
+    with pytest.raises(RuntimeError):
+
+        @decorators._handle_klio
+        @decorators._retry(tries=1, delay=invalid_delay)
+        def func(*args, **kwargs):
+            pass
+
+        func(kmsg.SerializeToString())


### PR DESCRIPTION
<!--- Describe your changes 

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

Add a `@retry` decorator for users to decorate their transforms with.  I've included some rudimentary unit tests.

<!--- How have you tested this?
Some valid responses are:

* "I have included unit tests" 
* "I have included integration tests"
* "I successfully ran my jobs with this code"

-->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [x] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [x] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [x] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
