### PR TITLE
[cli] Add create-resources flag and default to not creating external …

### DIFF
--- a/cli/src/klio_cli/cli.py
+++ b/cli/src/klio_cli/cli.py
@@ -248,10 +248,7 @@ def _validate_job_name(ctx, param, value):
 
 @job.command(
     "create",
-    help=(
-        "Create a new Klio job. This generates the necessary files as well as "
-        "the required Google Cloud resources."
-    ),
+    help=("Create the necessary files for a new Klio job."),
     context_settings=dict(
         ignore_unknown_options=True,
         allow_extra_args=True,

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -1,7 +1,4 @@
-# -*- coding: utf-8 -*-
 # Copyright 2019 Spotify AB
-
-from __future__ import absolute_import
 
 import copy
 import os
@@ -173,6 +170,7 @@ def minimal_config_data():
 def minimal_mock_klio_config(
     mock_klio_config, config_file, minimal_config_data
 ):
+
     mock_klio_config.setup(minimal_config_data, config_file)
     return mock_klio_config
 
@@ -1044,7 +1042,6 @@ def test_profile_memory(runner, mocker, minimal_mock_klio_config):
 
 def test_profile_memory_per_line(runner, mocker, minimal_mock_klio_config):
     mock_profile = mocker.patch.object(cli, "_profile")
-
     result = runner.invoke(cli.profile_memory_per_line, [])
 
     assert_execution_success(result)


### PR DESCRIPTION
In `klio job create`, default to not creating external resources. 

Updated unit tests and tested locally.

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ x] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ x] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ x] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
