### PR TITLE
[cli, exec, lib] new profile decorator, support for profiling basic transforms, bug fixes

### DIFF
--- a/cli/src/klio_cli/cli.py
+++ b/cli/src/klio_cli/cli.py
@@ -563,6 +563,14 @@ def _profile(subcommand, klio_config, config_meta, **kwargs):
     pipeline = job_commands.profile.ProfilePipeline(
         config_meta.job_dir, klio_config, runtime_config, profile_config
     )
+
+    # TODO: Add the docs
+    warnings.warn(
+        "Warning! Profiling currently does not support all use cases and"
+        "may not work with your job!  Please check the docs for more"
+        "information."
+    )
+
     pipeline.run(what=subcommand, subcommand_flags=kwargs)
 
 
@@ -592,7 +600,7 @@ def _profile(subcommand, klio_config, config_meta, **kwargs):
 @click.argument("entity_ids", nargs=-1, required=False)
 @cli_utils.with_klio_config
 def profile_memory(klio_config, config_meta, **kwargs):
-    _profile("memory", klio_config, **kwargs)
+    _profile("memory", klio_config, config_meta, **kwargs)
 
 
 @profile.command(
@@ -619,7 +627,7 @@ def profile_memory(klio_config, config_meta, **kwargs):
 @click.argument("entity_ids", nargs=-1, required=False)
 @cli_utils.with_klio_config
 def profile_memory_per_line(klio_config, config_meta, **kwargs):
-    _profile("memory-per-line", klio_config, **kwargs)
+    _profile("memory-per-line", klio_config, config_meta, **kwargs)
 
 
 @profile.command(
@@ -646,7 +654,7 @@ def profile_memory_per_line(klio_config, config_meta, **kwargs):
 @click.argument("entity_ids", nargs=-1, required=False)
 @cli_utils.with_klio_config
 def profile_cpu(klio_config, config_meta, **kwargs):
-    _profile("cpu", klio_config, **kwargs)
+    _profile("cpu", klio_config, config_meta, **kwargs)
 
 
 @profile.command(
@@ -673,7 +681,7 @@ def profile_cpu(klio_config, config_meta, **kwargs):
 @click.argument("entity_ids", nargs=-1, required=False)
 @cli_utils.with_klio_config
 def profile_timeit(klio_config, config_meta, **kwargs):
-    _profile("timeit", klio_config, **kwargs)
+    _profile("timeit", klio_config, config_meta, **kwargs)
 
 
 #####

--- a/cli/tests/commands/job/test_create.py
+++ b/cli/tests/commands/job/test_create.py
@@ -914,8 +914,14 @@ def test_parse_unknown_args(unknown_args, expected, job):
 @pytest.mark.parametrize("create_dockerfile", (True, False))
 @pytest.mark.parametrize("use_fnapi", (True, False))
 @pytest.mark.parametrize("create_resources", (True, False))
-def test_create(use_fnapi, create_dockerfile, create_resources, mocker, caplog, job):
-    context = {"job_name": "test-job", "use_fnapi": use_fnapi, "create_resources": create_resources}
+def test_create(
+    use_fnapi, create_dockerfile, create_resources, mocker, caplog, job
+):
+    context = {
+        "job_name": "test-job",
+        "use_fnapi": use_fnapi,
+        "create_resources": create_resources,
+    }
 
     mock_get_user_input = mocker.patch.object(job, "_get_user_input")
     mock_get_user_input.return_value = (context, create_dockerfile)
@@ -930,9 +936,12 @@ def test_create(use_fnapi, create_dockerfile, create_resources, mocker, caplog, 
     mock_create_dockerfile = mocker.patch.object(job, "_create_dockerfile")
     mock_create_readme = mocker.patch.object(job, "_create_readme")
 
-    mock_create_topics = mocker.patch.object(create.gcp_setup, "create_topics_and_buckets")
-    mock_create_stackdriver = mocker.patch.object(create.gcp_setup, "create_stackdriver_dashboard")
-
+    mock_create_topics = mocker.patch.object(
+        create.gcp_setup, "create_topics_and_buckets"
+    )
+    mock_create_stackdriver = mocker.patch.object(
+        create.gcp_setup, "create_stackdriver_dashboard"
+    )
 
     unknown_args = ("--foo", "bar")
     known_args = {

--- a/cli/tests/commands/message/test_publish.py
+++ b/cli/tests/commands/message/test_publish.py
@@ -55,7 +55,6 @@ def klio_job_config():
 @pytest.fixture
 def expected_klio_job(klio_job_config):
     klio_job = klio_pb2.KlioJob()
-    job_input = klio_job.JobInput()
     klio_job.job_name = "test-job"
     klio_job.gcp_project = "test-gcp-project"
     return klio_job
@@ -117,7 +116,9 @@ def test_get_current_klio_job(klio_job_config, expected_klio_job):
         (False, False, False, 2),
     ),
 )
-def test_create_pubsub_message(force, ping, top_down, version, expected_klio_job):
+def test_create_pubsub_message(
+    force, ping, top_down, version, expected_klio_job
+):
     entity_id = "s0m3-ent1ty-1D"
     expected_klio_message = klio_pb2.KlioMessage()
     expected_klio_message.metadata.force = force

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -1036,7 +1036,10 @@ def test_profile_memory(runner, mocker, minimal_mock_klio_config):
         "entity_ids": (),
     }
     mock_profile.assert_called_once_with(
-        "memory", minimal_mock_klio_config.klio_config, **exp_kwargs
+        "memory",
+        minimal_mock_klio_config.klio_config,
+        minimal_mock_klio_config.meta,
+        **exp_kwargs
     )
 
 
@@ -1057,7 +1060,10 @@ def test_profile_memory_per_line(runner, mocker, minimal_mock_klio_config):
         "entity_ids": (),
     }
     mock_profile.assert_called_once_with(
-        "memory-per-line", minimal_mock_klio_config.klio_config, **exp_kwargs
+        "memory-per-line",
+        minimal_mock_klio_config.klio_config,
+        minimal_mock_klio_config.meta,
+        **exp_kwargs
     )
 
 
@@ -1079,7 +1085,10 @@ def test_profile_cpu(runner, mocker, minimal_mock_klio_config):
         "entity_ids": (),
     }
     mock_profile.assert_called_once_with(
-        "cpu", minimal_mock_klio_config.klio_config, **exp_kwargs
+        "cpu",
+        minimal_mock_klio_config.klio_config,
+        minimal_mock_klio_config.meta,
+        **exp_kwargs
     )
 
 
@@ -1102,7 +1111,10 @@ def test_profile_timeit(
         "entity_ids": (),
     }
     mock_profile.assert_called_once_with(
-        "timeit", mock_klio_config.klio_config, **exp_kwargs
+        "timeit",
+        mock_klio_config.klio_config,
+        mock_klio_config.meta,
+        **exp_kwargs
     )
 
 

--- a/core/setup.py
+++ b/core/setup.py
@@ -64,7 +64,7 @@ INSTALL_REQUIRES = [
     "google-api-python-client>=1.10.0",
     "google-api-core>1.18.0,<1.21.0",  # TODO: try and remove
     "google-cloud-pubsub<=1.4.0",  # TODO: try and remove
-    "protobuf",
+    "protobuf>=3.12.0",
     "pyyaml",
     "six",
     "attrs",

--- a/docs/src/reference/cli/index.rst
+++ b/docs/src/reference/cli/index.rst
@@ -13,3 +13,65 @@ Klio CLI
 
    api
    changelog
+
+
+Profiling
+=========
+
+.. caution::
+   Profiling support is currently limited and may not work for your job!
+
+
+Currently Klio supports profiling single-argument functions (like those used in
+Beam ``Map`` and ``Flatmap`` transforms), ``DoFn`` classes, and partially
+supports methods in arbitrary classes.
+
+To profile a function, just add the ``profile`` decorator:
+
+.. code-block:: python
+
+    @decorators.handle_klio
+    @decorators.profile
+    def my_map_func(ctx, item):
+        yield item
+
+
+
+Be sure that ``profile`` is the *last* decorator applied to the function.
+
+To add profiling to any class that extends ``DoFn``, add the decorator to the class itself:
+
+.. code-block:: python
+
+    @decorators.profile
+    class MyDoFn(beam.DoFn):
+
+        @decorators.handle_klio
+        def process(self, item):
+            yield item
+
+
+Lastly, you can add profiling to any class method, however be aware that the class itself will never be instantiated and ``self`` will be ``None``:
+
+.. code-block:: python
+
+    class MyClass(object):
+
+        @decorators.handle_klio
+        @decorators.profile
+        def process(self, item):
+            yield item
+
+
+How Does Profiling Work
+------------------------
+
+When ``klio job profile`` is run, Klio will look for any object with the
+``profile`` decorator and add that object to a custom pipline.  Then, it will
+take the ids provided on the command-line, duplicate each one a number of
+times, and run the pipeline with those ids.
+
+This means that all decorated transforms will receive the same set of ids and
+run in an undefined order.  This may cause issues if your pipeline consists of
+multiple transforms that have to run in order, or where one transform depends
+on the value of ``payload``.

--- a/exec/src/klio_exec/commands/utils/profile_utils.py
+++ b/exec/src/klio_exec/commands/utils/profile_utils.py
@@ -1,17 +1,26 @@
 # Copyright 2020 Spotify AB
 
+import enum
+import inspect
 import logging
+import warnings
 
+# black conflicts with flake8 here
+# fmt: off
+import apache_beam as beam
+import attr
 try:
     import matplotlib.pyplot as plt
 except ImportError:  # pragma: no cover
     # can be a problem on MacOS w certain Python & OS versions
     # https://stackoverflow.com/a/34583958/1579977
     import matplotlib
-
     matplotlib.use("TkAgg")
     import matplotlib.pyplot as plt
 import numpy as np
+# fmt: on
+
+from klio.transforms import decorators
 
 
 def _get_profiling_data(filename):
@@ -61,3 +70,86 @@ def plot(input_file, output_file, x_label, y_label, title):
     plt.title(title)
     plt.grid()
     plt.savefig(output_file)
+
+
+class ProfileObjectType(enum.Enum):
+    DOFN = "dofn"
+    FUNCTION = "function"
+    METHOD = "method"
+
+
+@attr.attrs
+class ProfileObject(object):
+    """Wraps classes, methods, functions for profiling.  Takes care of putting
+    them in a proper beam transform, if necessary."""
+
+    obj_type = attr.attrib()
+    obj = attr.attrib()
+
+    @classmethod
+    def from_object(cls, obj):
+        if inspect.isclass(obj) and issubclass(obj, beam.DoFn):
+            return ProfileObject(ProfileObjectType.DOFN, obj)
+        elif callable(obj):
+            args = inspect.getfullargspec(obj).args
+            if len(args) == 1:
+                return ProfileObject(ProfileObjectType.FUNCTION, obj)
+            elif len(args) == 2:
+                if args[0] == "self":
+                    warnings.warn(
+                        "profiling methods may not work, self will be None!"
+                    )
+                    return ProfileObject(ProfileObjectType.METHOD, obj)
+                else:
+                    warnings.warn(
+                        "profiling 2-argument function, assuming first argument"
+                        "is klio context, which will be None when profiling"
+                    )
+                    # technically not a method, but works the same way
+                    return ProfileObject(ProfileObjectType.METHOD, obj)
+            else:
+                raise Exception(
+                    "cannot profile function with {} arguments".format(
+                        len(args)
+                    )
+                )
+        else:
+            raise Exception(
+                (
+                    "Attempting to profile unrecognized object {}"
+                    ", only DoFn classes and single-argument"
+                    "methods/functions supported"
+                ).format(obj)
+            )
+
+    def _name_entity_from_args(self, args):
+        if self.obj_type == ProfileObjectType.DOFN:
+            transform_name = args[0].__class__.__name__
+            entity_id = args[1]
+        elif self.obj_type == ProfileObjectType.FUNCTION:
+            transform_name = "function"
+            entity_id = args[0]
+        elif self.obj_type == ProfileObjectType.METHOD:
+            transform_name = "method"
+            entity_id = args[1]
+        return {"transform_name": transform_name, "entity_id": entity_id}
+
+    def to_wrapped_transform(self, wrapper_fn):
+        if self.obj_type == ProfileObjectType.DOFN:
+            process_method = getattr(self.obj, "process")
+            process_method = wrapper_fn(process_method)
+            setattr(self.obj, "process", process_method)
+            return beam.ParDo(self.obj())
+        elif self.obj_type == ProfileObjectType.FUNCTION:
+            wrapped = wrapper_fn(self.obj)
+            return beam.Map(wrapped)
+        else:
+            wrapped = wrapper_fn(self.obj)
+            return beam.Map(lambda x: wrapped(None, x))
+
+
+def load_profile_objects():
+    # NOTE: this function assumes user code has already been loaded, so that
+    # anything using the `profile` decorator is already registered
+    for raw_obj in decorators.PROFILE_OBJECTS:
+        yield ProfileObject.from_object(raw_obj)

--- a/exec/src/klio_exec/commands/utils/wrappers.py
+++ b/exec/src/klio_exec/commands/utils/wrappers.py
@@ -55,16 +55,12 @@ def _print_user_exceptions_func(func):
     return wrapper
 
 
-def print_user_exceptions(transforms):
+def print_user_exceptions(profile_fn):
     # Don't crap out if the process method errors; just continue profiling
-    for txf in transforms:
-        process_method = getattr(txf, "process")
-        if inspect.isgeneratorfunction(process_method):
-            process_method = _print_user_exceptions_generator(process_method)
-        else:
-            process_method = _print_user_exceptions_func(process_method)
-        setattr(txf, "process", process_method)
-        yield txf
+    if inspect.isgeneratorfunction(profile_fn):
+        return _print_user_exceptions_generator(profile_fn)
+    else:
+        return _print_user_exceptions_func(profile_fn)
 
 
 # adapted from line_profiler; memory_profiler doesn't handle generator

--- a/exec/tests/unit/commands/utils/test_wrappers.py
+++ b/exec/tests/unit/commands/utils/test_wrappers.py
@@ -82,13 +82,13 @@ def dummy_gen(x):
     ),
 )
 def test_print_user_exceptions_generators(transform, print_msg, capsys):
-    transform, *_ = list(wrappers.print_user_exceptions([transform]))
+    transform = wrappers.print_user_exceptions(transform.process)
 
     # fails without functools.wraps(func)
-    assert "process" == transform.process.__name__
+    assert "process" == transform.__name__
 
     # first argument is "self" of the process method
-    result = transform.process(None, 10)
+    result = transform(None, 10)
 
     assert 20 == next(result)
     assert 30 == next(result)
@@ -107,13 +107,13 @@ def test_print_user_exceptions_generators(transform, print_msg, capsys):
     ),
 )
 def test_print_user_exceptions_funcs(transform, print_msg, exp_ret, capsys):
-    transform, *_ = list(wrappers.print_user_exceptions([transform]))
+    transform = wrappers.print_user_exceptions(transform.process)
 
     # fails without functools.wraps(func)
-    assert "process" == transform.process.__name__
+    assert "process" == transform.__name__
 
     # first argument is "self" of the process method
-    result = transform.process(None, 10)
+    result = transform(None, 10)
 
     assert exp_ret == result
     captured = capsys.readouterr()

--- a/lib/src/klio/transforms/decorators.py
+++ b/lib/src/klio/transforms/decorators.py
@@ -689,3 +689,37 @@ def retry(
         exception_message=exception_message,
         **kwargs,
     )
+
+
+# objects marked for profiling are collected here and picked up by klio-exec
+# when the `profile` commands are used
+PROFILE_OBJECTS = []
+
+
+@_utils.experimental()
+def profile():
+    """Mark class/method/function for profiling.
+
+    This decorator is used in conjunction with the ``klio job profile``
+    commands to mark which code you wish to profile.  In order to work
+    properly, **this must be the last decorator applied**.
+
+    You can currently add this decorator to DoFn classes or any method/function
+    used with ``@handle_klio``.  In these cases, ``self`` (with class methods)
+    and ``ctx`` with functions decorated with ``@handle_klio`` will be
+    ``None``.  Decorated classes will be initialized with no arguments.
+
+    .. code-block:: python
+
+        @handle_klio
+        @profile()
+        def my_map_func(ctx, item):
+            ctx.logger.info(f"Received {item.element} with {item.payload}")
+
+    """
+
+    def inner(obj):
+        PROFILE_OBJECTS.append(obj)
+        return obj
+
+    return inner


### PR DESCRIPTION
This sort-of fixes profiling in v2.  "sort-of" because this basically supports what v1 supported, although it definitely will not work in some cases.

The new `@profile` decorator can be added to classes, methods, and single-argument functions.  It must be the last decorator applied otherwise line profiling ends up outputting the lines of the decorator, not user code itself.

I added support for adding the decorator to classes since when adding it to methods, `self` currently will be `None` (since the method is "unbounded" and we can't easily know what class it belongs to when the decorator is applied), in cases where user code may require `self`.  Still doesn't handle every situation, and I think we may need to go back to the drawing board a little to really have comprehensive profiling support, but I think this should handle the common use-cases for now.

Also fixed a few bugs with the CLI commands.

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ ] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
