### PR TITLE
[docs] Add pdf & epub format generation for readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,7 @@
 version: 2
 sphinx:
   configuration: docs/src/conf.py
-formats:
-  - pdf
-  - epub
+formats: all # formats key is actually about additional formats beyond HTML (whose generation is implied)
 python:
   # NOTE: Keep version in sync with gh-actions
   version: 3.7


### PR DESCRIPTION
# Hej I have a pull request

This PR (should) enable readthedocs to generate a PDF version of our documentation.

This (blasphemy) is to make it possible to print and read and end-to-end version of our documentation so we can do a full "style read" of our documentation to make sure that it is stylistically consistent. Unfortunately the best way I've found to do that is still with a printed out and stapled version of the words on paper with a pen and a highlighter as the prelude to a pull request.

And to make up for my PDF-generating sins, I've also enabled epub generation as well.

We should discuss turning this off before launch but should be thought of as an interim thing pre-launch.