### PR TITLE
[cli, exec, lib] Remove effective-klio-job.yaml

### DIFF
--- a/cli/src/klio_cli/cli.py
+++ b/cli/src/klio_cli/cli.py
@@ -139,9 +139,6 @@ def run_job(klio_config, config_meta, **kwargs):
         config_meta.job_dir, kwargs.get("image_tag")
     )
     image_tag = kwargs.get("image_tag") or git_sha
-    if config_meta.config_file:
-        basename = os.path.basename(config_meta.config_file)
-        image_tag = "{}-{}".format(image_tag, basename)
 
     runtime_config = DockerRuntimeConfig(
         image_tag=image_tag,

--- a/cli/src/klio_cli/commands/job/run.py
+++ b/cli/src/klio_cli/commands/job/run.py
@@ -35,6 +35,7 @@ class RunPipeline(base.BaseDockerizedPipeline):
     ):
         super().__init__(job_dir, klio_config, docker_runtime_config)
         self.run_job_config = run_job_config
+        self.requires_config_file = True
 
     @staticmethod
     def _try_container_kill(container):
@@ -114,14 +115,6 @@ class RunPipeline(base.BaseDockerizedPipeline):
             self.run_job_config.update is False
         ):  # don't do anything if `None`
             command.append("--no-update")
-
-        if self.docker_runtime_config.config_file_override:
-            command.extend(
-                [
-                    "--config-file",
-                    self.docker_runtime_config.config_file_override,
-                ]
-            )
 
         return command
 

--- a/cli/tests/commands/job/test_run.py
+++ b/cli/tests/commands/job/test_run.py
@@ -197,8 +197,7 @@ def test_get_environment(run_pipeline):
 
 
 @pytest.mark.parametrize(
-    "config_file,exp_config_flags",
-    ((None, []), ("klio-job2.yaml", ["--config-file", "klio-job2.yaml"])),
+    "config_file", (None, "klio-job2.yaml"),
 )
 @pytest.mark.parametrize(
     "image_tag,exp_image_flags",
@@ -219,7 +218,6 @@ def test_get_command(
     image_tag,
     exp_image_flags,
     config_file,
-    exp_config_flags,
     run_pipeline,
     monkeypatch,
 ):
@@ -236,7 +234,6 @@ def test_get_command(
     exp_command.extend(exp_update_flag)
     exp_command.extend(exp_runner_flag)
     exp_command.extend(exp_image_flags)
-    exp_command.extend(exp_config_flags)
 
     assert sorted(exp_command) == sorted(run_pipeline._get_command())
 

--- a/cli/tests/commands/test_base.py
+++ b/cli/tests/commands/test_base.py
@@ -252,7 +252,9 @@ def test_setup_docker_image(
         mock_build_docker_image.assert_not_called()
 
 
-def test_check_docker_setup(base_pipeline, mocker, monkeypatch):
+def test_check_docker_setup(
+    base_pipeline, mock_docker_client, mocker, monkeypatch
+):
     mock_check_docker_conn = mocker.Mock()
     monkeypatch.setattr(
         base.docker_utils, "check_docker_connection", mock_check_docker_conn
@@ -262,6 +264,10 @@ def test_check_docker_setup(base_pipeline, mocker, monkeypatch):
         base.docker_utils,
         "check_dockerfile_present",
         mock_check_dockerfile_present,
+    )
+
+    monkeypatch.setattr(
+        base.docker, "from_env", mock_docker_client,
     )
 
     base_pipeline._check_docker_setup()

--- a/core/src/klio_core/_testing.py
+++ b/core/src/klio_core/_testing.py
@@ -1,0 +1,90 @@
+# Copyright 2020 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from klio_core import config as kconfig
+from klio_core import utils as core_utils
+
+
+def assert_execution_success(result):
+    """Helper for testing CLI commands that emits errors if execution failed"""
+    if result.exception:
+        if result.stdout:
+            print("captured stdout: {}".format(result.stdout))
+        raise result.exception
+
+    assert 0 == result.exit_code
+
+
+class MockKlioConfig(object):
+    def __init__(self, module, mocker, monkeypatch, patch_os_getcwd):
+
+        self.mock_get_config = mocker.patch.object(
+            core_utils, "get_config_by_path"
+        )
+        self.mock_get_config_job_dir = mocker.Mock()
+        monkeypatch.setattr(
+            module.core_utils,
+            "get_config_job_dir",
+            self.mock_get_config_job_dir,
+        )
+
+        self.module = module
+        self.patch_os_getcwd = patch_os_getcwd
+        self.mocker = mocker
+        self.monkeypatch = monkeypatch
+
+    def setup(self, config_data, config_file, config_override=None):
+        self.config_override = config_override
+        self.config_data = config_data
+        self.config_file = config_file
+
+        self.mock_warn_if_py2_job = self.mocker.Mock()
+        self.monkeypatch.setattr(
+            self.module.core_utils,
+            "warn_if_py2_job",
+            self.mock_warn_if_py2_job,
+        )
+
+        self.mock_get_config_job_dir.return_value = (
+            self.patch_os_getcwd,
+            config_override or config_file,
+        )
+
+        self.mock_get_config.return_value = config_data
+
+        self.meta = core_utils.KlioConfigMeta(
+            job_dir=self.patch_os_getcwd,
+            config_file=config_override,
+            config_path=config_override or config_file,
+        )
+
+        self.klio_config = kconfig.KlioConfig(config_data)
+
+        self.mock_klio_config = self.mocker.patch.object(
+            core_utils.config, "KlioConfig"
+        )
+        self.mock_klio_config.return_value = self.klio_config
+
+        return self.klio_config
+
+    def assert_calls(self):
+        self.mock_get_config_job_dir.assert_called_once_with(
+            None, self.config_override
+        )
+        self.mock_get_config.assert_called_once_with(
+            self.config_override or self.config_file
+        )
+        self.mock_klio_config.assert_called_once_with(self.config_data)
+        self.mock_warn_if_py2_job.assert_called_once_with(self.patch_os_getcwd)

--- a/core/src/klio_core/utils.py
+++ b/core/src/klio_core/utils.py
@@ -247,6 +247,9 @@ def with_klio_config(func):
 #############################
 def warn_if_py2_job(job_dir):
     dockerfile_path = os.path.join(job_dir, "Dockerfile")
+    if not os.path.isfile(dockerfile_path):
+        return
+
     from_line = None
     with open(dockerfile_path, "r") as f:
         for line in f.readlines():

--- a/devtools/src/klio_devtools/commands/develop.py
+++ b/devtools/src/klio_devtools/commands/develop.py
@@ -42,6 +42,7 @@ class DevelopKlioContainer(base.BaseDockerizedPipeline):
         self.install_pkgs = [
             pkg for pkg in self.PKGS if pkg not in exclude_pkgs
         ]
+        self.requires_config_file = False
 
     def _run_docker_container(self, runflags):
         """

--- a/exec/tests/unit/commands/test_run.py
+++ b/exec/tests/unit/commands/test_run.py
@@ -126,19 +126,6 @@ def _config():
     return mock_config
 
 
-# NOTE: Python decorators are evaluated on import, and so importing
-# `klio_exec.commands.run` (which imports `klio.transforms.helpers`,
-# which imports `klio.transforms.decorators`) triggers the  code in those
-# decorators to get evaluated. Therefore, we must patch this part in
-# order to import it, otherwise it will try to load the non-existant
-# `/usr/src/config/.effective-klio-job.yaml`
-mock_config = _config()
-patcher = mock.patch(
-    "klio.transforms.core.KlioContext._load_config_from_file",
-    lambda x: mock_config,
-)
-patcher.start()
-
 from klio_exec.commands import run  # noqa E402
 
 

--- a/exec/tests/unit/test_cli.py
+++ b/exec/tests/unit/test_cli.py
@@ -25,6 +25,16 @@ from click import testing
 from klio_core import config as kconfig
 
 
+def assert_execution_success(result):
+    """Helper for testing CLI commands that emits errors if execution failed"""
+    if result.exception:
+        if result.stdout:
+            print("captured stdout: {}".format(result.stdout))
+        raise result.exception
+
+    assert 0 == result.exit_code
+
+
 @pytest.fixture
 def mock_os_getcwd(monkeypatch):
     test_dir = "/test/dir"
@@ -92,8 +102,7 @@ def klio_config(config):
 # `/usr/src/config/.effective-klio-job.yaml`
 mock_config = kconfig.KlioConfig(_config())
 patcher = mock.patch(
-    "klio.transforms.core.KlioContext._load_config_from_file",
-    lambda x: mock_config,
+    "klio.transforms.core.RunConfig.get", lambda: mock_config,
 )
 patcher.start()
 
@@ -114,14 +123,7 @@ def patch_klio_config(monkeypatch, klio_config):
 @pytest.fixture
 def patch_run_basic_pipeline(mocker, monkeypatch):
     mock = mocker.Mock()
-    monkeypatch.setattr(cli.run.KlioPipeline, "run", mock)
-    return mock
-
-
-@pytest.fixture
-def mock_compare_runtime_to_buildtime_config(mocker, monkeypatch):
-    mock = mocker.Mock()
-    monkeypatch.setattr(cli, "_compare_runtime_to_buildtime_config", mock)
+    mocker.patch("klio_exec.commands.run.KlioPipeline.run", mock)
     return mock
 
 
@@ -159,43 +161,6 @@ def test_get_config_raises(tmpdir, caplog):
     assert 1 == len(caplog.records)
 
 
-@pytest.mark.parametrize(
-    "addl_runtime_data,buildtime_exists,exp_retval",
-    (
-        ({}, True, True),
-        ({"baz": "bla"}, True, False),
-        ({}, False, True),
-        ({"baz": "bla"}, False, True),  # not possible but CYA
-    ),
-)
-def test_compare_runtime_to_buildtime_config(
-    mocker, monkeypatch, addl_runtime_data, buildtime_exists, exp_retval
-):
-    monkeypatch.setattr(os.path, "exists", lambda x: buildtime_exists)
-
-    buildtime_data = {"foo": "bar"}
-    runtime_data = buildtime_data.copy()
-    runtime_data.update(addl_runtime_data)
-
-    # multiple `open` mocks: https://stackoverflow.com/a/26830397/1579977
-    open_name = "klio_exec.cli.open"
-    buildtime_data_str = yaml.dump(buildtime_data).encode("utf-8")
-    runtime_data_str = yaml.dump(runtime_data).encode("utf-8")
-
-    mock_open_buildtime = mocker.mock_open(read_data=buildtime_data_str)
-    mock_open_runtime = mocker.mock_open(read_data=runtime_data_str)
-    mock_open = mocker.patch(open_name, mock_open_buildtime)
-
-    side_effect = (
-        mock_open_runtime.return_value,
-        mock_open_buildtime.return_value,
-    )
-    mock_open.side_effect = side_effect
-
-    act_retval = cli._compare_runtime_to_buildtime_config("klio-job.yaml")
-    assert exp_retval == act_retval
-
-
 @pytest.mark.parametrize("blocking", (True, False, None))
 @pytest.mark.parametrize(
     "image_tag,direct_runner,update",
@@ -218,9 +183,7 @@ def test_run_pipeline(
     patch_get_config,
     patch_run_basic_pipeline,
     patch_klio_config,
-    mock_compare_runtime_to_buildtime_config,
 ):
-    mock_compare_runtime_to_buildtime_config.return_value = True
     runtime_conf = cli.RuntimeConfig(
         image_tag=None, direct_runner=False, update=None, blocking=None
     )
@@ -250,35 +213,23 @@ def test_run_pipeline(
     assert 0 == result.exit_code
 
     patch_run_basic_pipeline.assert_called_once_with()
-    mock_compare_runtime_to_buildtime_config.assert_called_once_with(
-        "klio-job.yaml"
-    )
 
 
 @pytest.mark.parametrize(
-    "config_file_override,compare_conf_retval",
-    (
-        (None, True),
-        (None, False),
-        ("klio-job2.yaml", True),
-        ("klio-job2.yaml", False),
-    ),
+    "config_file_override", (None, "klio-job2.yaml"),
 )
 def test_run_pipeline_conf_override(
     config_file_override,
-    compare_conf_retval,
     cli_runner,
     config,
     klio_config,
     patch_get_config,
     patch_run_basic_pipeline,
     patch_klio_config,
-    mock_compare_runtime_to_buildtime_config,
     caplog,
     tmpdir,
     monkeypatch,
 ):
-    mock_compare_runtime_to_buildtime_config.return_value = compare_conf_retval
 
     cli_inputs = []
 
@@ -300,15 +251,7 @@ def test_run_pipeline_conf_override(
 
     patch_run_basic_pipeline.assert_called_once_with()
 
-    mock_compare_runtime_to_buildtime_config.assert_called_once_with(
-        exp_conf_file
-    )
-
-    if compare_conf_retval is False:
-        assert 1 == len(caplog.records)
-        assert "WARNING" == caplog.records[0].levelname
-    else:
-        assert 0 == len(caplog.records)
+    assert 0 == len(caplog.records)
 
 
 @pytest.mark.parametrize("config_file_override", (None, "klio-job2.yaml"))
@@ -358,15 +301,22 @@ def test_stop_job(
         ["test_file.py::test_foo test:file_.py::test_foo2 -s"],
     ],
 )
-def test_test_job(pytest_args, mocker, monkeypatch, cli_runner):
+def test_test_job(
+    pytest_args,
+    mocker,
+    monkeypatch,
+    cli_runner,
+    patch_get_config,
+    patch_klio_config,
+):
     mock_test = mocker.Mock()
     monkeypatch.setattr(pytest, "main", mock_test)
     mock_test.return_value = 0
 
     result = cli_runner.invoke(cli.test_job, pytest_args)
 
+    assert_execution_success(result)
     assert "true" == os.environ["KLIO_TEST_MODE"]
-    assert 0 == result.exit_code
 
     mock_test.assert_called_once_with(pytest_args)
 
@@ -380,7 +330,14 @@ def test_test_job(pytest_args, mocker, monkeypatch, cli_runner):
         ["test_file.py::test_foo test:file_.py::test_foo2 -s"],
     ],
 )
-def test_test_job_raises(pytest_args, mocker, monkeypatch, cli_runner):
+def test_test_job_raises(
+    pytest_args,
+    mocker,
+    monkeypatch,
+    cli_runner,
+    patch_get_config,
+    patch_klio_config,
+):
     mock_test = mocker.Mock()
     mock_test.return_value = 1
     monkeypatch.setattr(pytest, "main", mock_test)

--- a/lib/tests/unit/conftest.py
+++ b/lib/tests/unit/conftest.py
@@ -104,7 +104,6 @@ def mock_config(mocker, monkeypatch):
     mock_data_input.skip_klio_existence_check = True
     mconfig.job_config.data.inputs = [mock_data_input]
     monkeypatch.setattr(
-        "klio.transforms.core.KlioContext._load_config_from_file",
-        lambda x: mconfig,
+        "klio.transforms.core.RunConfig.get", lambda: mconfig,
     )
     return mconfig


### PR DESCRIPTION
Two main important changes in this PR:

### Config hand-off from CLI to exec

When CLI `run` invokes exec `run`, it now generates a "materialized" config file on the fly and hands it off to exec (purposely using "materialized" instead of "effective" to eliminate any possible confusion with the existing effective config).  This file includes any overrides and template parameters applied, so exec doesn't have to worry about any of that and just reads the generated file as-is.  

This basically solves the problem of how to propagate config overrides from CLI to exec.

Note: since we have since decided to add all config parsing support to exec to support Luigi (which will bypass CLI and call exec directly), an alternative approach could have been to simply pass-on all overrides as command-line parameters when CLI invokes exec.  However, personally I think this is still a cleaner solution but I'm happy to discuss this further.


### Exec config pickling

Once exec has loaded config, it uses `RunConfig` to set a main-session global variable to the config object.  When the beam pipeline starts, Beam itself will automatically pickle all main-session vars and include them on Dataflow workers (and of course in direct-runner too).  This eliminates the need for workers to load `effective-klio-job.yaml` currently included in docker images and python packages.

This solves two problems:
1.  Since `effective-klio-job.yaml` was included during `klio image build`, there could be a mismatch between the packaged config file and the actual file when users run `klio job run`.  We currently warn about this, but it still leads to confusion.  Plus, right now making any config change requires re-running `klio image build`.
2.  Similarly, this also meant that we had no easy way to support config overrides, since even though klio CLI can parse the overrides and modify its config, klio exec still just loaded the packaged file.  On dataflow workers, this could happen before any code is executed since some decorators read config and thus config is needed as code using the decorators is imported.



## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ ] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
