### PR TITLE
[docs] Remove building all formats (just default to html)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,6 @@
 version: 2
 sphinx:
   configuration: docs/src/conf.py
-formats: all # formats key is actually about additional formats beyond HTML (whose generation is implied)
 python:
   # NOTE: Keep version in sync with gh-actions
   version: 3.7


### PR DESCRIPTION
<!--- Describe your changes 

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

[This commit](https://github.com/spotify/klio/pull/70/commits/32e36996f74fbf859b52035f4a2c884935db5619) caused the building of `epub` format in RTDs to [fail](https://readthedocs.com/projects/spotify-klio-klio/builds/433425/). This is because epub uses a different theme (default behavior), and can't load one of the panda's template in the new `docs/src/_templates/layout.html`. I don't know how to tell epub to ignore all this, so it's easier to just turn it off for now.

<!--- How have you tested this?
Some valid responses are:

* "I have included unit tests" 
* "I have included integration tests"
* "I successfully ran my jobs with this code"

-->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ ] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
