### PR TITLE
[cli] job create - default use_fnapi to False

### DIFF
--- a/cli/src/klio_cli/commands/job/create.py
+++ b/cli/src/klio_cli/commands/job/create.py
@@ -49,7 +49,7 @@ DEFAULTS = {
     "disk_size_gb": 32,
     "worker_machine_type": "n1-standard-2",
     "python_version": "3.6",
-    "use_fnapi": True,
+    "use_fnapi": False,
     "create_resources": False,
 }
 

--- a/cli/tests/commands/job/test_create.py
+++ b/cli/tests/commands/job/test_create.py
@@ -163,13 +163,13 @@ def default_context():
     return {
         "job_name": "test-job",
         "python_version": "36",
-        "use_fnapi": True,
+        "use_fnapi": False,
         "create_resources": False,
         "pipeline_options": {
             "project": "test-gcp-project",
             "region": "europe-west1",
             "worker_harness_container_image": gcr_url,
-            "experiments": ["beam_fn_api"],
+            "experiments": [],
             "staging_location": base_gcs + "/staging",
             "temp_location": base_gcs + "/temp",
             "num_workers": 2,


### PR DESCRIPTION
FnAPI is still technically experimental, so let's not default to using it in `klio job create`.

<!--- How have you tested this?

* "I have included unit tests" 
I also have a local integration test (that I will make a PR for when klio is open-sourced) that worked.

-->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ x] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ x] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ x] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
