### PR TITLE
[exec] Ensure that 'deployed_by' label value respects label format

### DIFF
--- a/exec/src/klio_exec/commands/run.py
+++ b/exec/src/klio_exec/commands/run.py
@@ -197,11 +197,17 @@ class KlioPipeline(object):
             if os_value:
                 labels.append("{}={}".format(label, os_value))
 
+        deploy_user = os.environ.get("USER")
         if os.environ.get("CI", "").lower() == "true":
             # TODO: maybe provide way to allow something besides just "CI"
-            labels.append("deployed_by=CI")
-        elif os.environ.get("USER"):
-            labels.append("deployed_by={}".format(os.environ["USER"].lower()))
+            deploy_user = "ci"
+
+        if deploy_user:
+            deploy_label = "deployed_by={}".format(
+                KlioPipeline._get_clean_label_value(deploy_user)
+            )
+
+            labels.append(deploy_label)
 
         gcp_opts.labels = labels
 

--- a/exec/tests/unit/commands/test_run.py
+++ b/exec/tests/unit/commands/test_run.py
@@ -464,7 +464,7 @@ def test_set_google_cloud_options(
         "klio={}".format(klio_lib_version_clean),
     ]
     if user:
-        exp_labels.append("deployed_by={}".format(user))
+        exp_labels.append("deployed_by={}".format(user).lower())
     if klio_cli_version:
         exp_labels.append("klio-cli={}".format(klio_cli_version_clean))
     assert sorted(exp_labels) == sorted(actual_gcp_opts.labels)


### PR DESCRIPTION
_This is a port of one of the commits from internal `klio` master that didn't make it into the initial public `klio` branch._ 

This PR refactors the set up of the `deployed_by` label  to use `exec.run.KlioPipeline._get_clean_label_value` to make sure the label's value follows the expected format.

Dataflow recently(?) started enforcing its rules around label values, which means users will encounter this an invalid label error, something like:
```
Encountered an invalid user label. generic::invalid_argument: Invalid field "user_labels.deployed_by"; value "CI" does not conform to regular expression "[\p{Ll}\p{Lo}\p{N}_-]{0,63}"; character "C" at position 0 is not a non-uppercased letter (Unicode character class Ll or Lo), digit, hyphen, or underscore [google.rpc.error_details_ext] { message: "Invalid field \"user_labels.deployed_by\"; value \"CI\" does not conform to regular expression \"[\\p{Ll}\\p{Lo}\\p{N}_-]{0,63}\"; character \"C\" at position 0 is not a non-uppercased letter (Unicode character class Ll or Lo), digit, hyphen, or underscore" }
```

<!--- How have you tested this?
I have included unit tests.
-->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [x] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [x] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [x] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
