### PR TITLE
[devtools] use 2020-resolver, new package exclude option

### DIFF
--- a/devtools/src/klio_devtools/cli.py
+++ b/devtools/src/klio_devtools/cli.py
@@ -56,6 +56,9 @@ from klio_devtools.commands import develop
     help="Path to klio repo",
     required=True,
 )
+@click.option(
+    "--exclude", help="exclude installing a particular package", multiple=True,
+)
 def develop_job(job_dir, config_file, **kwargs):
     job_dir, config_path = cli_utils.get_config_job_dir(job_dir, config_file)
     config_data = config_utils.get_config_by_path(config_path)
@@ -74,6 +77,6 @@ def develop_job(job_dir, config_file, **kwargs):
     )
 
     klio_pipeline = develop.DevelopKlioContainer(
-        job_dir, conf, runtime_config, kwargs["klio_path"],
+        job_dir, conf, runtime_config, kwargs["klio_path"], kwargs["exclude"]
     )
     klio_pipeline.run()


### PR DESCRIPTION
few small updates to devtools I found helpful:

1.  `pip` now uses the `2020-resolver` feature.  
2.  added a `--exclude` option to exclude installing a package.  Kinda only makes sense for `klio-audio` right now, but I found it useful since that one take the longest to install and usually isn't needed
3.  minor refactoring 

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ ] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
