### PR TITLE
[docs] Light Github Icon css

### DIFF
--- a/docs/src/_static/css/custom.css
+++ b/docs/src/_static/css/custom.css
@@ -94,3 +94,11 @@ blockquote p {
 .header-style, h1, h2, h3, h4, h5, h6 {
   font-family: HK-Grotesk;
 }
+
+/*
+  "Social Service" icons.
+  Make Github icon light mode.
+*/
+i.fa-github-square::before {
+	color: #f8f9fa;
+}


### PR DESCRIPTION
Change Github icon css to light theme so it stands out on dark topnav.

<!--- Describe your changes 

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

<!--- How have you tested this?
Some valid responses are:

* "I have included unit tests" 
* "I have included integration tests"
* "I successfully ran my jobs with this code"

-->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [x] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
