### PR TITLE
[cli] set google-cloud-monitoring < 2.0.0

### DIFF
--- a/cli/setup.py
+++ b/cli/setup.py
@@ -81,7 +81,7 @@ INSTALL_REQUIRES = [
     "glom",
     "google-api-core>1.18.0,<1.21.0",
     "google-api-python-client>=1.10.0",
-    "google-cloud-monitoring",
+    "google-cloud-monitoring<2.0.0",
     # API breaking change w google-api-core
     "google-cloud-pubsub<=1.4.0",
     "google-cloud-storage<1.30.0",


### PR DESCRIPTION
Fixing a dependency version conflict:

```
google-cloud-monitoring 2.0.0 requires google-api-core[grpc]<2.0.0dev,>=1.22.2, but you'll have google-api-core 1.20.1 which is incompatible.
```

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ ] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
