### PR TITLE
[site] Fix icon sizes for non-chrome browsers

### DIFF
--- a/microsite/css/main.css
+++ b/microsite/css/main.css
@@ -78,7 +78,9 @@ button.gradient:hover {
 }
 .animated-icons {
   max-width: 15%;
-  height: auto;
+  max-height: 15%;
+  width: 15%;
+  height: 15%;
 }
 .logo {
   max-width: 150%;
@@ -119,7 +121,9 @@ button.gradient:hover {
   }
   .animated-icons {
     max-width: 25%;
-    height: auto;
+    max-height: 25%;
+    width: 25%;
+    height: 25%;
   }
 }
 


### PR DESCRIPTION
<!--- Describe your changes 

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

On safari (desktop and mobile), the icons looked weird:

<img width="686" alt="Screen Shot 2020-10-21 at 3 16 29 PM" src="https://user-images.githubusercontent.com/1191069/96772009-769b6780-13b0-11eb-9205-9ca892cf48fd.png">

There may be a smarter way but I'm not a front end person and this is a quick fix ¯\\_(ツ)_/¯ 

<!--- How have you tested this?
Some valid responses are:

* "I have included unit tests" 
* "I have included integration tests"
* "I successfully ran my jobs with this code"

-->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ ] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
