### PR TITLE
pin pip to 20.2.3 in dependency check workflow

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -31,11 +31,12 @@ jobs:
         with:
           python-version: "3.6"
       - name: "Install dependencies"
+        # pin pip version until https://github.com/pypa/pip/issues/9011 is resolved
         run: |
           set -xe
           python -VV
           python -m site
-          python -m pip install --upgrade pip setuptools
+          python -m pip install --upgrade pip==20.2.3 setuptools
       - name: "Install klio_core"
         run: |
           python -m pip install -e core --use-feature=2020-resolver
@@ -57,7 +58,7 @@ jobs:
           set -xe
           python -VV
           python -m site
-          python -m pip install --upgrade pip setuptools
+          python -m pip install --upgrade pip==20.2.3 setuptools
       - name: "Install klio_core"
         run: |
           python -m pip install -e core --use-feature=2020-resolver


### PR DESCRIPTION
Due to an apparent bug in pip 20.2.4, if a dependency conflict occurs when using `--use-feature=2020-resolver` pip gets stuck in an infinite loop, hence the reason why some of our workflows are running for over 6 hours before getting killed.


## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ ] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
