### PR TITLE
[lib] limit apache-beam version <2.25.0

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -74,7 +74,7 @@ CLASSIFIERS = [
 META_FILE = read(META_PATH)
 INSTALL_REQUIRES = [
     # 2.22 added DirectRunner support for `DoFn.setup`
-    "apache-beam[gcp]>2.21.0",
+    "apache-beam[gcp]>2.21.0,<2.25.0",
     "google-api-python-client",
     "klio-core>=0.2.0",
     "protobuf",


### PR DESCRIPTION
2.25.0 has transitive dependencies that cause conflicts:

```
google-cloud-build 2.0.0 has requirement google-api-core[grpc]<2.0.0dev,>=1.22.0, but you have google-api-core 1.20.1.
google-cloud-bigquery 1.28.0 has requirement google-api-core<2.0dev,>=1.21.0, but you have google-api-core 1.20.1.
```

Also, `2.25.0` has changed `BigQuerySource` from a class to a function, and since we have classes that inherit from it, Klio is currently incompatible with it.

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ ] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
