### PR TITLE
[cli] Bump version: 1.0.0 → 1.0.1

### DIFF
--- a/cli/setup.cfg
+++ b/cli/setup.cfg
@@ -1,14 +1,15 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 1.0.1
 tag_name = cli-{new_version}
 commit = True
 tag = True
 message = [cli] Bump version: {current_version} → {new_version}
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
-serialize =
+serialize = 
 	{major}.{minor}.{patch}
 
 [bumpversion:file:src/klio_cli/__init__.py]
 
 [bdist_wheel]
 universal = 1
+

--- a/cli/src/klio_cli/__init__.py
+++ b/cli/src/klio_cli/__init__.py
@@ -14,7 +14,7 @@
 #
 
 __author__ = "The klio developers"
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 __email__ = "opensource+klio@spotify.com"
 __description__ = "Main entrypoint for Klio jobs"
 __uri__ = "https://github.com/spotify/klio"


### PR DESCRIPTION
Releasing cli-1.0.1, which includes:

**Fixes**
* [PR 100](https://github.com/spotify/klio/pull/100): set google-cloud-monitoring < 2.0.0. This impacts users who have encountered the infinite dependency resolution issue in versions of pip using the new 2020 resolver [issue](https://github.com/pypa/pip/issues/9011). 




## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ ] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
