### PR TITLE
[cli, core, exec, lib] unpin google lib versions, support beam 2.25

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -38,11 +38,11 @@ jobs:
           python -m pip install --upgrade pip setuptools
       - name: "Install klio_core"
         run: |
-          python -m pip install -e core --use-feature=2020-resolver
+          python -m pip install -e core
           python -m pip check
       - name: "Install klio_cli"
         run: |
-          python -m pip install -e cli --use-feature=2020-resolver
+          python -m pip install -e cli
           python -m pip check
   core_lib_exec_checks:
     name: "klio: verify no dependency conflicts between core/lib/exec"
@@ -60,13 +60,13 @@ jobs:
           python -m pip install --upgrade pip setuptools
       - name: "Install klio_core"
         run: |
-          python -m pip install -e core --use-feature=2020-resolver
+          python -m pip install -e core
           python -m pip check
       - name: "Install klio_lib"
         run: |
-          python -m pip install -e lib --use-feature=2020-resolver
+          python -m pip install -e lib
           python -m pip check
       - name: "Install klio_exec"
         run: |
-          python -m pip install -e exec --use-feature=2020-resolver
+          python -m pip install -e exec
           python -m pip check

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -151,21 +151,18 @@ PROJECT_URLS = {
 }
 META_FILE = read(META_PATH)
 INSTALL_REQUIRES = [
+    "klio-core>=0.2.0",
     "click",
     "dateparser",
     "docker",
     "emoji",
     "jinja2",
     "glom",
-    "google-api-core>1.18.0,<1.21.0",
-    "google-api-python-client>=1.10.0",
-    "google-cloud-monitoring<2.0.0",
-    # API breaking change w google-api-core
-    "google-cloud-pubsub<=1.4.0",
-    "google-cloud-storage<1.30.0",
-    # API breaking change w google-cloud-monitoring
-    "googleapis-common-protos<1.50.0",
-    "klio-core>=0.2.0",
+    "google-api-core",
+    "google-api-python-client",
+    "google-cloud-monitoring",
+    "google-cloud-pubsub",
+    "google-cloud-storage",
     "protobuf",
     "pyyaml",
     "setuptools",

--- a/core/setup.py
+++ b/core/setup.py
@@ -153,9 +153,9 @@ META_FILE = read(META_PATH)
 INSTALL_REQUIRES = [
     "click",
     "glom",
-    "google-api-python-client>=1.10.0,<1.12",
-    "google-api-core>1.18.0,<1.21.0",  # TODO: try and remove
-    "google-cloud-pubsub<=1.4.0",  # TODO: try and remove
+    "google-api-python-client",
+    "google-api-core",  # TODO: try and remove
+    "google-cloud-pubsub",  # TODO: try and remove
     "protobuf",
     "pyyaml",
     "six",

--- a/core/setup.py
+++ b/core/setup.py
@@ -154,9 +154,10 @@ INSTALL_REQUIRES = [
     "click",
     "glom",
     "google-api-python-client",
-    "google-api-core",  # TODO: try and remove
+    "google-api-core>=1.21.0",  # TODO: try and remove
+    "google-cloud-core>=1.4.1",
     "google-cloud-pubsub",  # TODO: try and remove
-    "protobuf",
+    "protobuf>=3.12.0",
     "pyyaml",
     "six",
     "attrs",

--- a/exec/tox.ini
+++ b/exec/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py36,py37,py38}-beam{22,23,24},docs,manifest,check-formatting,lint
+envlist = {py36,py37,py38}-beam{23,24,25},docs,manifest,check-formatting,lint
 
 [testenv]
 setenv =
@@ -12,9 +12,9 @@ deps =
     {toxinidir}/../lib
     ; apache-beam is already installed from above, but there's no way to
     ; dynamically edit setup.py in a decent way to update version dep
-    beam22: apache-beam[gcp]>=2.22.0,<2.23.0
     beam23: apache-beam[gcp]>=2.23.0,<2.24.0
     beam24: apache-beam[gcp]>=2.24.0,<2.25.0
+    beam25: apache-beam[gcp]>=2.25.0,<2.26.0
     ; we'll leave old SDKs as a tox env available to invoke manually, but
     ; remove from `envlist` so they're not ran by default
 commands =

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -152,7 +152,7 @@ PROJECT_URLS = {
 META_FILE = read(META_PATH)
 INSTALL_REQUIRES = [
     # 2.22 added DirectRunner support for `DoFn.setup`
-    "apache-beam[gcp]>2.21.0,<2.25.0",
+    "apache-beam[gcp]>2.21.0",
     "google-api-python-client",
     "klio-core>=0.2.0",
     "protobuf",

--- a/lib/tests/unit/transforms/test_core.py
+++ b/lib/tests/unit/transforms/test_core.py
@@ -168,6 +168,8 @@ def test_job_property(thread_local_ret, mocker, monkeypatch):
         mock_func.assert_not_called()
         assert klio_ns._thread_local.klio_job == ret_value
 
+    klio_ns._thread_local.klio_job = None
+
 
 @pytest.mark.parametrize("thread_local_ret", (True, False))
 def test_metrics_property(thread_local_ret, mocker, monkeypatch):

--- a/lib/tox.ini
+++ b/lib/tox.ini
@@ -1,14 +1,14 @@
 [tox]
-envlist = {py36,py37,py38}-beam{22,23,24},docs,manifest,check-formatting,lint
+envlist = {py36,py37,py38}-beam{23,24,25},docs,manifest,check-formatting,lint
 
 [testenv]
 install_command = python -m pip install {opts} {packages}
 extras = tests
 deps =
     {toxinidir}/../core
-    beam22: apache-beam[gcp]>=2.22.0,<2.23.0
     beam23: apache-beam[gcp]>=2.23.0,<2.24.0
     beam24: apache-beam[gcp]>=2.24.0,<2.25.0
+    beam25: apache-beam[gcp]>=2.25.0,<2.26.0
     ; we'll leave old SDKs as a tox env available to invoke manually, but
     ; remove from `envlist` so they're not ran by default
 commands =


### PR DESCRIPTION
* Removing most of the versions restriction on google lib dependencies.
* including testing with beam 2.25 (left 2.22 in for now but we can probably stop testing on it soon)
* removing use of `2020-resolver` in dependency check workflow because of pip issues

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [x] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [x] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
