### PR TITLE
[all] Deprecate py35, update pkg classifiers & add long descriptions

### DIFF
--- a/.github/workflows/audio.yml
+++ b/.github/workflows/audio.yml
@@ -29,7 +29,7 @@ jobs:
     #   USING_COVERAGE: '3.7'
     strategy:
       matrix:
-        python-version: ["3.5", "3.6", "3.7", "3.8"]
+        python-version: ["3.6", "3.7", "3.8"]
       # do not cancel other jobs in matrix if one fails
       fail-fast: false
     steps:

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -31,7 +31,7 @@ jobs:
     #   USING_COVERAGE: '3.7'
     strategy:
       matrix:
-        python-version: ["3.5", "3.6", "3.7", "3.8"]
+        python-version: ["3.6", "3.7", "3.8"]
       # do not cancel other jobs in matrix if one fails
       fail-fast: false
     steps:

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -29,7 +29,7 @@ jobs:
     #   USING_COVERAGE: '3.7'
     strategy:
       matrix:
-        python-version: ["3.5", "3.6", "3.7", "3.8"]
+        python-version: ["3.6", "3.7", "3.8"]
       # do not cancel other jobs in matrix if one fails
       fail-fast: false
     steps:

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -29,7 +29,7 @@ jobs:
     #   USING_COVERAGE: '3.7'
     strategy:
       matrix:
-        python-version: ["3.5", "3.6", "3.7", "3.8"]
+        python-version: ["3.6", "3.7", "3.8"]
       # do not cancel other jobs in matrix if one fails
       fail-fast: false
     steps:

--- a/.github/workflows/exec.yml
+++ b/.github/workflows/exec.yml
@@ -33,7 +33,7 @@ jobs:
     #   USING_COVERAGE: '3.7'
     strategy:
       matrix:
-        python-version: ["3.5", "3.6", "3.7", "3.8"]
+        python-version: ["3.6", "3.7", "3.8"]
       # do not cancel other jobs in matrix if one fails
       fail-fast: false
     steps:

--- a/.github/workflows/lib.yml
+++ b/.github/workflows/lib.yml
@@ -31,7 +31,7 @@ jobs:
     #   USING_COVERAGE: '3.7'
     strategy:
       matrix:
-        python-version: ["3.5", "3.6", "3.7", "3.8"]
+        python-version: ["3.6", "3.7", "3.8"]
       # do not cancel other jobs in matrix if one fails
       fail-fast: false
     steps:

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       python-version:
-        description: 'Python Version (3.5, 3.6, 3.7 or 3.8)'
+        description: 'Python Version (3.6, 3.7 or 3.8)'
         required: true
         default: '3.6'
       package:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -4,7 +4,7 @@ Contributing to the ``klio`` ecosystem
 Requirements
 ------------
 
-* Python 3.5, 3.6, 3.7, and 3.8 (suggestion: use `pyenv <https://github.com/pyenv/pyenv>`_ to install required versions)
+* Python 3.6, 3.7, and 3.8 (suggestion: use `pyenv <https://github.com/pyenv/pyenv>`_ to install required versions)
 * `tox <https://tox.readthedocs.io/en/latest/>`_ (suggestion: use `pipx <https://pypi.org/project/pipx/>`_ to install ``tox``)
 * `protoc <https://github.com/protocolbuffers/protobuf/>`_
 

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,9 @@
    :alt: Latest version of klio-core on PyPI
 
 
-.. defining roles used here so that github ignores them when rendering the README.
+.. defining roles used here so that github & PyPI project page ignores them when rendering the README.
+
+.. start-long-desc
 
 .. role:: violetemph
 

--- a/audio/README.rst
+++ b/audio/README.rst
@@ -13,12 +13,16 @@ The ``klio-audio`` Library
 
 ``klio-audio`` is an optional library with helper transforms related to processing audio, including downloading from `GCS`_ into memory, loading into `numpy`_ via `librosa`_, generate various spectrograms, among others.
 
-.. admonition:: Installation
-    :class: tip
+.. end-klio-audio-intro
 
-    To make use of ``klio-audio``, add ``klio[audio]`` in your ``job-requirements.txt`` file so that it is installed in your job's Docker image.
+Installation
+------------
 
-As the ``klio-audio`` library is not meant to be installed directly, check out the `installation
+To make use of ``klio-audio``, add ``klio[audio]`` in your ``job-requirements.txt`` file so that it is installed in your job's Docker image.
+
+.. start-klio-audio-install
+
+As the ``klio-audio`` library is **not** meant to be installed directly, check out the `installation
 guide <https://docs.klio.io/en/latest/quickstart/installation.html>`_ for how to setup
 installation.
 There is also the `user guide <https://docs.klio.io/en/latest/userguide/index.html>`_ and the `API

--- a/audio/setup.py
+++ b/audio/setup.py
@@ -70,6 +70,7 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: Implementation :: CPython",
+    "License :: OSI Approved :: Apache Software License",
 ]
 META_FILE = read(META_PATH)
 INSTALL_REQUIRES = [

--- a/audio/setup.py
+++ b/audio/setup.py
@@ -25,6 +25,7 @@ from setuptools import setup
 
 
 HERE = os.path.abspath(os.path.dirname(__file__))
+ROOT_DIR = os.path.abspath(os.path.join(HERE, os.path.pardir))
 
 
 #####
@@ -51,6 +52,69 @@ def find_meta(meta):
     if meta_match:
         return meta_match.group(1)
     raise RuntimeError("Unable to find __{meta}__ string.".format(meta=meta))
+
+
+def get_recent_changelog(filename):
+    """Grab the entry for the latest release."""
+    contents = read(filename).split("\n")
+    # Skip the title (first two lines)
+    contents = contents[2:]
+
+    # Find the latest release
+    start_line, end_line = None, None
+    for i, line in enumerate(contents):
+        # if we've found the start & end, we're done
+        if all([start_line, end_line]):
+            break
+
+        # 4 dashes are a horizontal line in rST, so look for headers with 5+
+        if line.startswith("-----"):
+            if start_line is None:
+                start_line = i - 1
+                continue
+            if end_line is None:
+                end_line = i - 1
+                continue
+
+    recent_log_lines = contents[start_line:end_line]
+    recent_log = "\n".join(recent_log_lines)
+    return recent_log
+
+
+def get_main_readme_intro():
+    """Grab the intro from the README from the root of the project."""
+    readme_path = os.path.join(ROOT_DIR, "README.rst")
+    contents = read(readme_path).split(".. start-long-desc")[1:]
+    return "\n".join(contents)
+
+
+def get_long_description(package_dir):
+    """Generate the long description from the README and changelog."""
+    cl_base_path = f"reference/{package_dir}/changelog"
+    cl_file_path = os.path.join(ROOT_DIR, f"docs/src/{cl_base_path}.rst")
+    cl_url = f"{PROJECT_URLS['Documentation']}/en/latest/{cl_base_path}.html"
+
+    # When tox builds the library, it loses where the ROOT_DIR is; this
+    # is also a problem with our integration tests. So we'll just ignore
+    # if there's an error and continue on
+    main_readme, recent_changelog = "", ""
+    try:
+        main_readme = get_main_readme_intro()
+        recent_changelog = get_recent_changelog(cl_file_path)
+    except Exception:
+        pass
+
+    desc = (
+        read("README.rst")
+        + "\n"
+        + main_readme
+        + "\n"
+        + "Release Information\n"
+        + "===================\n\n"
+        + recent_changelog
+        + f"\n\n`Full Changelog <{cl_url}>`_.\n\n"
+    )
+    return desc
 
 
 #####
@@ -115,6 +179,8 @@ setup(
     name=NAME,
     version=find_meta("version"),
     description=find_meta("description"),
+    long_description=get_long_description("audio"),
+    long_description_content_type="text/x-rst",
     url=find_meta("uri"),
     project_urls=PROJECT_URLS,
     keywords=KEYWORDS,

--- a/audio/setup.py
+++ b/audio/setup.py
@@ -66,7 +66,6 @@ CLASSIFIERS = [
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
@@ -93,8 +92,8 @@ EXTRAS_REQUIRE = {
 EXTRAS_REQUIRE["dev"] = (
     EXTRAS_REQUIRE["docs"] + EXTRAS_REQUIRE["tests"] + ["bumpversion", "wheel"]
 )
-# support 3.5, 3.6, 3.7, & 3.8, matching Beam's support
-PYTHON_REQUIRES = ">=3.5, <3.9"
+# support 3.6, 3.7, & 3.8, matching Beam's support
+PYTHON_REQUIRES = ">=3.6, <3.9"
 
 
 setup(

--- a/audio/setup.py
+++ b/audio/setup.py
@@ -71,7 +71,21 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: Implementation :: CPython",
     "License :: OSI Approved :: Apache Software License",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Multimedia",
+    "Topic :: Multimedia :: Graphics",
+    "Topic :: Multimedia :: Sound/Audio",
+    "Topic :: Multimedia :: Video",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Image Processing",
 ]
+KEYWORDS = ["klio", "apache", "beam", "audio"]
+PROJECT_URLS = {
+    "Documentation": "https://docs.klio.io",
+    "Bug Tracker": "https://github.com/spotify/klio/issues",
+    "Source Code": "https://github.com/spotify/klio"
+}
 META_FILE = read(META_PATH)
 INSTALL_REQUIRES = [
     # 2.22 added DirectRunner support for `DoFn.setup`
@@ -102,6 +116,8 @@ setup(
     version=find_meta("version"),
     description=find_meta("description"),
     url=find_meta("uri"),
+    project_urls=PROJECT_URLS,
+    keywords=KEYWORDS,
     author=find_meta("author"),
     author_email=find_meta("email"),
     maintainer=find_meta("author"),

--- a/audio/tox.ini
+++ b/audio/tox.ini
@@ -60,7 +60,6 @@ testpaths = tests
 ; required for mapping envs -> github runtimes
 [gh-actions]
 python =
-    3.5: py35
     3.6: py36, manifest, check-formatting,lint
     3.7: py37
     3.8: py38

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -70,7 +70,21 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: Implementation :: CPython",
     "License :: OSI Approved :: Apache Software License",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Multimedia",
+    "Topic :: Multimedia :: Graphics",
+    "Topic :: Multimedia :: Sound/Audio",
+    "Topic :: Multimedia :: Video",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Image Processing",
 ]
+KEYWORDS = ["klio", "apache", "beam", "audio"]
+PROJECT_URLS = {
+    "Documentation": "https://docs.klio.io",
+    "Bug Tracker": "https://github.com/spotify/klio/issues",
+    "Source Code": "https://github.com/spotify/klio"
+}
 META_FILE = read(META_PATH)
 INSTALL_REQUIRES = [
     "click",
@@ -115,6 +129,8 @@ setup(
     version=find_meta("version"),
     description=find_meta("description"),
     url=find_meta("uri"),
+    project_urls=PROJECT_URLS,
+    keywords=KEYWORDS,
     author=find_meta("author"),
     author_email=find_meta("email"),
     maintainer=find_meta("author"),

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -65,7 +65,6 @@ CLASSIFIERS = [
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
@@ -107,8 +106,8 @@ EXTRAS_REQUIRE["dev"] = (
     + EXTRAS_REQUIRE["tests"]
     + ["klio-devtools", "bumpversion", "wheel"]
 )
-# support 3.5, 3.6, 3.7, & 3.8, matching Beam's support
-PYTHON_REQUIRES = ">=3.5, <3.9"
+# support 3.6, 3.7, & 3.8, matching Beam's support
+PYTHON_REQUIRES = ">=3.6, <3.9"
 
 setup(
     name=NAME,

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -69,6 +69,7 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: Implementation :: CPython",
+    "License :: OSI Approved :: Apache Software License",
 ]
 META_FILE = read(META_PATH)
 INSTALL_REQUIRES = [

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -24,6 +24,7 @@ from setuptools import setup
 
 
 HERE = os.path.abspath(os.path.dirname(__file__))
+ROOT_DIR = os.path.abspath(os.path.join(HERE, os.path.pardir))
 
 
 #####
@@ -50,6 +51,69 @@ def find_meta(meta):
     if meta_match:
         return meta_match.group(1)
     raise RuntimeError("Unable to find __{meta}__ string.".format(meta=meta))
+
+
+def get_recent_changelog(filename):
+    """Grab the entry for the latest release."""
+    contents = read(filename).split("\n")
+    # Skip the title (first two lines)
+    contents = contents[2:]
+
+    # Find the latest release
+    start_line, end_line = None, None
+    for i, line in enumerate(contents):
+        # if we've found the start & end, we're done
+        if all([start_line, end_line]):
+            break
+
+        # 4 dashes are a horizontal line in rST, so look for headers with 5+
+        if line.startswith("-----"):
+            if start_line is None:
+                start_line = i - 1
+                continue
+            if end_line is None:
+                end_line = i - 1
+                continue
+
+    recent_log_lines = contents[start_line:end_line]
+    recent_log = "\n".join(recent_log_lines)
+    return recent_log
+
+
+def get_main_readme_intro():
+    """Grab the intro from the README from the root of the project."""
+    readme_path = os.path.join(ROOT_DIR, "README.rst")
+    contents = read(readme_path).split(".. start-long-desc")[1:]
+    return "\n".join(contents)
+
+
+def get_long_description(package_dir):
+    """Generate the long description from the README and changelog."""
+    cl_base_path = f"reference/{package_dir}/changelog"
+    cl_file_path = os.path.join(ROOT_DIR, f"docs/src/{cl_base_path}.rst")
+    cl_url = f"{PROJECT_URLS['Documentation']}/en/latest/{cl_base_path}.html"
+
+    # When tox builds the library, it loses where the ROOT_DIR is; this
+    # is also a problem with our integration tests. So we'll just ignore
+    # if there's an error and continue on
+    main_readme, recent_changelog = "", ""
+    try:
+        main_readme = get_main_readme_intro()
+        recent_changelog = get_recent_changelog(cl_file_path)
+    except Exception:
+        pass
+
+    desc = (
+        read("README.rst")
+        + "\n"
+        + main_readme
+        + "\n"
+        + "Release Information\n"
+        + "===================\n\n"
+        + recent_changelog
+        + f"\n\n`Full Changelog <{cl_url}>`_.\n\n"
+    )
+    return desc
 
 
 #####
@@ -128,6 +192,8 @@ setup(
     name=NAME,
     version=find_meta("version"),
     description=find_meta("description"),
+    long_description=get_long_description("cli"),
+    long_description_content_type="text/x-rst",
     url=find_meta("uri"),
     project_urls=PROJECT_URLS,
     keywords=KEYWORDS,

--- a/cli/src/klio_cli/commands/job/create.py
+++ b/cli/src/klio_cli/commands/job/create.py
@@ -36,7 +36,7 @@ TOPIC_REGEX = re.compile(
     r"^projects/(?P<project>[a-z0-9-]{6,30})/"
     r"topics/(?P<topic>[a-zA-Z0-9-_.~+%]{3,255})"
 )
-VALID_BEAM_PY_VERSIONS = ["3.5", "3.6", "3.7"]
+VALID_BEAM_PY_VERSIONS = ["3.6", "3.7", "3.8"]
 
 DEFAULTS = {
     "region": "europe-west1",
@@ -189,7 +189,7 @@ class CreateJob(object):
             "{}".format(python_version, ", ".join(VALID_BEAM_PY_VERSIONS))
         )
 
-        # valid examples: 35, 3.5, 3.5.6
+        # valid examples: 36, 3.6, 3.6.6
         if len(python_version) < 2 or len(python_version) > 5:
             raise click.BadParameter(invalid_err_msg)
 

--- a/cli/src/klio_cli/options.py
+++ b/cli/src/klio_cli/options.py
@@ -365,7 +365,7 @@ def until(func):
     )(func)
 
 
-# https://docs.python.org/3.5/library/profile.html#pstats.Stats.sort_stats
+# https://docs.python.org/3.6/library/profile.html#pstats.Stats.sort_stats
 # unfortunately, can't get this dynamically <3.7 (@lynn)
 SORT_STATS_KEY = [
     "calls",

--- a/cli/src/klio_cli/utils/cli_utils.py
+++ b/cli/src/klio_cli/utils/cli_utils.py
@@ -105,7 +105,7 @@ def warn_if_py2_job(job_dir):
     if from_image in py2_dataflow_images:
         msg = (
             "Python 2 support in Klio is deprecated. Please upgrade "
-            "to Python 3.5+."
+            "to Python 3.6+."
         )
         warnings.warn(msg, category=UserWarning)
 

--- a/cli/tests/commands/job/test_create.py
+++ b/cli/tests/commands/job/test_create.py
@@ -419,12 +419,12 @@ def test_validate_region_raises(job):
 @pytest.mark.parametrize(
     "input_version,exp_output_version",
     (
-        ("3.5", "3.5"),
-        ("3.5.1", "3.5"),
         ("3.6", "3.6"),
         ("3.6.1", "3.6"),
         ("3.7", "3.7"),
         ("3.7.1", "3.7"),
+        ("3.8", "3.8"),
+        ("3.8.1", "3.8"),
     ),
 )
 def test_parse_python_version(input_version, exp_output_version, job):

--- a/cli/tests/utils/test_cli_utils.py
+++ b/cli/tests/utils/test_cli_utils.py
@@ -43,7 +43,7 @@ def test_warn_if_py2_job(image, patch_os_getcwd, mocker):
 
     warn_msg = (
         "Python 2 support in Klio is deprecated. "
-        "Please upgrade to Python 3.5+"
+        "Please upgrade to Python 3.6+"
     )
     with pytest.warns(UserWarning, match=warn_msg):
         cli_utils.warn_if_py2_job(patch_os_getcwd)

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,py38,docs,manifest,check-formatting,lint
+envlist = py36,py37,py38,docs,manifest,check-formatting,lint
 
 [testenv]
 install_command = python -m pip install {opts} {packages}
@@ -80,7 +80,6 @@ filterwarnings =
 ; required for mapping envs -> github runtimes
 [gh-actions]
 python =
-    3.5: py35
     3.6: py36, docs, manifest, check-formatting,lint
     3.7: py37
     3.8: py38

--- a/core/README.rst
+++ b/core/README.rst
@@ -13,5 +13,5 @@ The ``klio-core`` Package
 
 A library of common utilities, including the Klio `protobuf definitions <https://docs.klio.io/en/latest/userguide/pipeline/message.html>`_ and configuration parsing.
 
-As the ``klio-core`` package is not meant to be installed directly, check out the `installation guide <https://docs.klio.io/en/latest/quickstart/installation.html>`_ for how to setup installation.
+As the ``klio-core`` package is **not** meant to be installed directly, check out the `installation guide <https://docs.klio.io/en/latest/quickstart/installation.html>`_ for how to setup installation.
 There is also the `user guide <https://docs.klio.io/en/latest/userguide/index.html>`_ and the `API documentation <https://docs.klio.io/en/latest/reference/core/index.html>`_ for more information.

--- a/core/setup.py
+++ b/core/setup.py
@@ -70,7 +70,21 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: Implementation :: CPython",
     "License :: OSI Approved :: Apache Software License",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Multimedia",
+    "Topic :: Multimedia :: Graphics",
+    "Topic :: Multimedia :: Sound/Audio",
+    "Topic :: Multimedia :: Video",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Image Processing",
 ]
+KEYWORDS = ["klio", "apache", "beam", "audio"]
+PROJECT_URLS = {
+    "Documentation": "https://docs.klio.io",
+    "Bug Tracker": "https://github.com/spotify/klio/issues",
+    "Source Code": "https://github.com/spotify/klio"
+}
 META_FILE = read(META_PATH)
 INSTALL_REQUIRES = [
     "glom",
@@ -103,6 +117,8 @@ setup(
     version=find_meta("version"),
     description=find_meta("description"),
     url=find_meta("uri"),
+    project_urls=PROJECT_URLS,
+    keywords=KEYWORDS,
     author=find_meta("author"),
     author_email=find_meta("email"),
     maintainer=find_meta("author"),

--- a/core/setup.py
+++ b/core/setup.py
@@ -65,7 +65,6 @@ CLASSIFIERS = [
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
@@ -94,8 +93,8 @@ EXTRAS_REQUIRE = {
 EXTRAS_REQUIRE["dev"] = (
     EXTRAS_REQUIRE["docs"] + EXTRAS_REQUIRE["tests"] + ["bumpversion", "wheel"]
 )
-# support 3.5, 3.6, 3.7, & 3.8, matching Beam's support
-PYTHON_REQUIRES = ">=3.5, <3.9"
+# support 3.6, 3.7, & 3.8, matching Beam's support
+PYTHON_REQUIRES = ">=3.6, <3.9"
 
 
 setup(

--- a/core/setup.py
+++ b/core/setup.py
@@ -69,6 +69,7 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: Implementation :: CPython",
+    "License :: OSI Approved :: Apache Software License",
 ]
 META_FILE = read(META_PATH)
 INSTALL_REQUIRES = [

--- a/core/setup.py
+++ b/core/setup.py
@@ -24,6 +24,7 @@ from setuptools import setup
 
 
 HERE = os.path.abspath(os.path.dirname(__file__))
+ROOT_DIR = os.path.abspath(os.path.join(HERE, os.path.pardir))
 
 
 #####
@@ -50,6 +51,69 @@ def find_meta(meta):
     if meta_match:
         return meta_match.group(1)
     raise RuntimeError("Unable to find __{meta}__ string.".format(meta=meta))
+
+
+def get_recent_changelog(filename):
+    """Grab the entry for the latest release."""
+    contents = read(filename).split("\n")
+    # Skip the title (first two lines)
+    contents = contents[2:]
+
+    # Find the latest release
+    start_line, end_line = None, None
+    for i, line in enumerate(contents):
+        # if we've found the start & end, we're done
+        if all([start_line, end_line]):
+            break
+
+        # 4 dashes are a horizontal line in rST, so look for headers with 5+
+        if line.startswith("-----"):
+            if start_line is None:
+                start_line = i - 1
+                continue
+            if end_line is None:
+                end_line = i - 1
+                continue
+
+    recent_log_lines = contents[start_line:end_line]
+    recent_log = "\n".join(recent_log_lines)
+    return recent_log
+
+
+def get_main_readme_intro():
+    """Grab the intro from the README from the root of the project."""
+    readme_path = os.path.join(ROOT_DIR, "README.rst")
+    contents = read(readme_path).split(".. start-long-desc")[1:]
+    return "\n".join(contents)
+
+
+def get_long_description(package_dir):
+    """Generate the long description from the README and changelog."""
+    cl_base_path = f"reference/{package_dir}/changelog"
+    cl_file_path = os.path.join(ROOT_DIR, f"docs/src/{cl_base_path}.rst")
+    cl_url = f"{PROJECT_URLS['Documentation']}/en/latest/{cl_base_path}.html"
+
+    # When tox builds the library, it loses where the ROOT_DIR is; this
+    # is also a problem with our integration tests. So we'll just ignore
+    # if there's an error and continue on
+    main_readme, recent_changelog = "", ""
+    try:
+        main_readme = get_main_readme_intro()
+        recent_changelog = get_recent_changelog(cl_file_path)
+    except Exception:
+        pass
+
+    desc = (
+        read("README.rst")
+        + "\n"
+        + main_readme
+        + "\n"
+        + "Release Information\n"
+        + "===================\n\n"
+        + recent_changelog
+        + f"\n\n`Full Changelog <{cl_url}>`_.\n\n"
+    )
+    return desc
 
 
 #####
@@ -116,6 +180,8 @@ setup(
     name=NAME,
     version=find_meta("version"),
     description=find_meta("description"),
+    long_description=get_long_description("core"),
+    long_description_content_type="text/x-rst",
     url=find_meta("uri"),
     project_urls=PROJECT_URLS,
     keywords=KEYWORDS,

--- a/core/tox.ini
+++ b/core/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,py38,docs,manifest,check-formatting,lint
+envlist = py36,py37,py38,docs,manifest,check-formatting,lint
 
 [testenv]
 install_command = python -m pip install {opts} {packages}
@@ -89,7 +89,6 @@ filterwarnings =
 ; required for mapping envs -> github runtimes
 [gh-actions]
 python =
-    3.5: py35
     3.6: py36, docs, manifest, check-formatting,lint
     3.7: py37
     3.8: py38

--- a/devtools/setup.py
+++ b/devtools/setup.py
@@ -24,6 +24,7 @@ from setuptools import setup
 
 
 HERE = os.path.abspath(os.path.dirname(__file__))
+ROOT_DIR = os.path.abspath(os.path.join(HERE, os.path.pardir))
 
 
 #####
@@ -50,6 +51,69 @@ def find_meta(meta):
     if meta_match:
         return meta_match.group(1)
     raise RuntimeError("Unable to find __{meta}__ string.".format(meta=meta))
+
+
+def get_recent_changelog(filename):
+    """Grab the entry for the latest release."""
+    contents = read(filename).split("\n")
+    # Skip the title (first two lines)
+    contents = contents[2:]
+
+    # Find the latest release
+    start_line, end_line = None, None
+    for i, line in enumerate(contents):
+        # if we've found the start & end, we're done
+        if all([start_line, end_line]):
+            break
+
+        # 4 dashes are a horizontal line in rST, so look for headers with 5+
+        if line.startswith("-----"):
+            if start_line is None:
+                start_line = i - 1
+                continue
+            if end_line is None:
+                end_line = i - 1
+                continue
+
+    recent_log_lines = contents[start_line:end_line]
+    recent_log = "\n".join(recent_log_lines)
+    return recent_log
+
+
+def get_main_readme_intro():
+    """Grab the intro from the README from the root of the project."""
+    readme_path = os.path.join(ROOT_DIR, "README.rst")
+    contents = read(readme_path).split(".. start-long-desc")[1:]
+    return "\n".join(contents)
+
+
+def get_long_description(package_dir):
+    """Generate the long description from the README and changelog."""
+    cl_base_path = f"reference/{package_dir}/changelog"
+    cl_file_path = os.path.join(ROOT_DIR, f"docs/src/{cl_base_path}.rst")
+    cl_url = f"{PROJECT_URLS['Documentation']}/en/latest/{cl_base_path}.html"
+
+    # When tox builds the library, it loses where the ROOT_DIR is; this
+    # is also a problem with our integration tests. So we'll just ignore
+    # if there's an error and continue on
+    main_readme, recent_changelog = "", ""
+    try:
+        main_readme = get_main_readme_intro()
+        recent_changelog = get_recent_changelog(cl_file_path)
+    except Exception:
+        pass
+
+    desc = (
+        read("README.rst")
+        + "\n"
+        + main_readme
+        + "\n"
+        + "Release Information\n"
+        + "===================\n\n"
+        + recent_changelog
+        + f"\n\n`Full Changelog <{cl_url}>`_.\n\n"
+    )
+    return desc
 
 
 #####
@@ -109,6 +173,8 @@ setup(
     name=NAME,
     version=find_meta("version"),
     description=find_meta("description"),
+    long_description=get_long_description("devtools"),
+    long_description_content_type="text/x-rst",
     url=find_meta("uri"),
     project_urls=PROJECT_URLS,
     keywords=KEYWORDS,

--- a/devtools/setup.py
+++ b/devtools/setup.py
@@ -69,6 +69,7 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: Implementation :: CPython",
+    "License :: OSI Approved :: Apache Software License",
 ]
 META_FILE = read(META_PATH)
 INSTALL_REQUIRES = [

--- a/devtools/setup.py
+++ b/devtools/setup.py
@@ -65,7 +65,6 @@ CLASSIFIERS = [
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
@@ -88,8 +87,8 @@ EXTRAS_REQUIRE = {
     ],
 }
 EXTRAS_REQUIRE["dev"] = EXTRAS_REQUIRE["tests"] + ["bumpversion", "wheel"]
-# support 3.5, 3.6, 3.7, & 3.8, matching Beam's support
-PYTHON_REQUIRES = ">=3.5, <3.9"
+# support 3.6, 3.7, & 3.8, matching Beam's support
+PYTHON_REQUIRES = ">=3.6, <3.9"
 
 setup(
     name=NAME,

--- a/devtools/setup.py
+++ b/devtools/setup.py
@@ -70,7 +70,21 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: Implementation :: CPython",
     "License :: OSI Approved :: Apache Software License",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Multimedia",
+    "Topic :: Multimedia :: Graphics",
+    "Topic :: Multimedia :: Sound/Audio",
+    "Topic :: Multimedia :: Video",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Image Processing",
 ]
+KEYWORDS = ["klio", "apache", "beam", "audio"]
+PROJECT_URLS = {
+    "Documentation": "https://docs.klio.io",
+    "Bug Tracker": "https://github.com/spotify/klio/issues",
+    "Source Code": "https://github.com/spotify/klio"
+}
 META_FILE = read(META_PATH)
 INSTALL_REQUIRES = [
     "click",
@@ -96,6 +110,8 @@ setup(
     version=find_meta("version"),
     description=find_meta("description"),
     url=find_meta("uri"),
+    project_urls=PROJECT_URLS,
+    keywords=KEYWORDS,
     author=find_meta("author"),
     author_email=find_meta("email"),
     maintainer=find_meta("author"),

--- a/devtools/tox.ini
+++ b/devtools/tox.ini
@@ -62,7 +62,6 @@ testpaths = tests
 ; required for mapping envs -> github runtimes
 [gh-actions]
 python =
-    3.5: py35
     3.6: py36, manifest, check-formatting, lint
     3.7: py37
     3.8: py38

--- a/docs/src/quickstart/installation.rst
+++ b/docs/src/quickstart/installation.rst
@@ -7,7 +7,7 @@ Requirements
 ------------
 
 * `git`_
-* Python version 3.5, 3.6, 3.7, or 3.8 (recommended installation via `pyenv`_)
+* Python version 3.6, 3.7, or 3.8 (recommended installation via `pyenv`_)
 * `Docker`_
 * Google Cloud SDK (:ref:`setup instructions below <gcloud-setup>`)
 * `pipx`_ (suggested) or `virtualenv`_ (`pyenv-virtualenv`_ when using `pyenv`_).

--- a/docs/src/reference/audio/index.rst
+++ b/docs/src/reference/audio/index.rst
@@ -7,6 +7,15 @@ Klio Audio
 
 .. include:: ../../../../audio/README.rst
     :start-after: start-klio-audio-intro
+    :end-before: end-klio-audio-intro
+
+.. admonition:: Installation
+    :class: tip
+
+    To make use of ``klio-audio``, add ``klio[audio]`` in your ``job-requirements.txt`` file so that it is installed in your job's Docker image.
+
+.. include:: ../../../../audio/README.rst
+    :start-after: start-klio-audio-install
 
 .. toctree::
    :maxdepth: 1

--- a/exec/README.rst
+++ b/exec/README.rst
@@ -12,11 +12,11 @@ The ``klio-exec`` Package
 
 .. start-klio-exec-intro
 
-The executor – meant to not be used directly by the user – is a CLI that launches a pipeline from within a job's Docker container (a.k.a. an Apache Beam's `"driver"`_).
+The executor – **not** meant to be used directly by the user – is a CLI that launches a pipeline from within a job's Docker container (a.k.a. an Apache Beam's `"driver"`_).
 Many commands from the ``klio-cli`` directly wrap to commands in the executor: a ``klio-cli`` command will set up the Docker context needed to correctly run the pipeline via the associated command with ``klio-exec``.
 The Docker context includes mounting the job directory, sets up environment variables, mounting credentials, etc.
 
-As the ``klio-exec`` package is not meant to be installed directly, check out the `installation guide <https://docs.klio.io/en/latest/quickstart/installation.html>`_ for how to setup installation.
+As the ``klio-exec`` package is **not** meant to be installed directly, check out the `installation guide <https://docs.klio.io/en/latest/quickstart/installation.html>`_ for how to setup installation.
 There is also the `user guide <https://docs.klio.io/en/latest/userguide/index.html>`_ and the `API documentation <https://docs.klio.io/en/latest/reference/executor/api.html>`_ for more information.
 
 

--- a/exec/setup.py
+++ b/exec/setup.py
@@ -70,7 +70,21 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: Implementation :: CPython",
     "License :: OSI Approved :: Apache Software License",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Multimedia",
+    "Topic :: Multimedia :: Graphics",
+    "Topic :: Multimedia :: Sound/Audio",
+    "Topic :: Multimedia :: Video",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Image Processing",
 ]
+KEYWORDS = ["klio", "apache", "beam", "audio"]
+PROJECT_URLS = {
+    "Documentation": "https://docs.klio.io",
+    "Bug Tracker": "https://github.com/spotify/klio/issues",
+    "Source Code": "https://github.com/spotify/klio"
+}
 META_FILE = read(META_PATH)
 INSTALL_REQUIRES = [
     "attrs",
@@ -122,6 +136,8 @@ setup(
     version=find_meta("version"),
     description=find_meta("description"),
     url=find_meta("uri"),
+    project_urls=PROJECT_URLS,
+    keywords=KEYWORDS,
     author=find_meta("author"),
     author_email=find_meta("email"),
     maintainer=find_meta("author"),

--- a/exec/setup.py
+++ b/exec/setup.py
@@ -69,6 +69,7 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: Implementation :: CPython",
+    "License :: OSI Approved :: Apache Software License",
 ]
 META_FILE = read(META_PATH)
 INSTALL_REQUIRES = [

--- a/exec/setup.py
+++ b/exec/setup.py
@@ -65,7 +65,6 @@ CLASSIFIERS = [
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
@@ -107,8 +106,8 @@ EXTRAS_REQUIRE["dev"] = (
     EXTRAS_REQUIRE["debug"] +
     ["bumpversion", "wheel"]
 )
-# support 3.5, 3.6, 3.7, & 3.8, matching Beam's support
-PYTHON_REQUIRES = ">=3.5, <3.9"
+# support 3.6, 3.7, & 3.8, matching Beam's support
+PYTHON_REQUIRES = ">=3.6, <3.9"
 AUDIT_PLUGIN_PATH = "klio_exec.commands.audit_steps."
 AUDIT_PLUGINS = [
     "tempfile=" + AUDIT_PLUGIN_PATH + "tempfile_usage:_init",

--- a/exec/setup.py
+++ b/exec/setup.py
@@ -24,6 +24,7 @@ from setuptools import setup
 
 
 HERE = os.path.abspath(os.path.dirname(__file__))
+ROOT_DIR = os.path.abspath(os.path.join(HERE, os.path.pardir))
 
 
 #####
@@ -50,6 +51,69 @@ def find_meta(meta):
     if meta_match:
         return meta_match.group(1)
     raise RuntimeError("Unable to find __{meta}__ string.".format(meta=meta))
+
+
+def get_recent_changelog(filename):
+    """Grab the entry for the latest release."""
+    contents = read(filename).split("\n")
+    # Skip the title (first two lines)
+    contents = contents[2:]
+
+    # Find the latest release
+    start_line, end_line = None, None
+    for i, line in enumerate(contents):
+        # if we've found the start & end, we're done
+        if all([start_line, end_line]):
+            break
+
+        # 4 dashes are a horizontal line in rST, so look for headers with 5+
+        if line.startswith("-----"):
+            if start_line is None:
+                start_line = i - 1
+                continue
+            if end_line is None:
+                end_line = i - 1
+                continue
+
+    recent_log_lines = contents[start_line:end_line]
+    recent_log = "\n".join(recent_log_lines)
+    return recent_log
+
+
+def get_main_readme_intro():
+    """Grab the intro from the README from the root of the project."""
+    readme_path = os.path.join(ROOT_DIR, "README.rst")
+    contents = read(readme_path).split(".. start-long-desc")[1:]
+    return "\n".join(contents)
+
+
+def get_long_description(package_dir):
+    """Generate the long description from the README and changelog."""
+    cl_base_path = f"reference/{package_dir}/changelog"
+    cl_file_path = os.path.join(ROOT_DIR, f"docs/src/{cl_base_path}.rst")
+    cl_url = f"{PROJECT_URLS['Documentation']}/en/latest/{cl_base_path}.html"
+
+    # When tox builds the library, it loses where the ROOT_DIR is; this
+    # is also a problem with our integration tests. So we'll just ignore
+    # if there's an error and continue on
+    main_readme, recent_changelog = "", ""
+    try:
+        main_readme = get_main_readme_intro()
+        recent_changelog = get_recent_changelog(cl_file_path)
+    except Exception:
+        pass
+
+    desc = (
+        read("README.rst")
+        + "\n"
+        + main_readme
+        + "\n"
+        + "Release Information\n"
+        + "===================\n\n"
+        + recent_changelog
+        + f"\n\n`Full Changelog <{cl_url}>`_.\n\n"
+    )
+    return desc
 
 
 #####
@@ -135,6 +199,8 @@ setup(
     name=NAME,
     version=find_meta("version"),
     description=find_meta("description"),
+    long_description=get_long_description("executor"),
+    long_description_content_type="text/x-rst",
     url=find_meta("uri"),
     project_urls=PROJECT_URLS,
     keywords=KEYWORDS,

--- a/exec/tox.ini
+++ b/exec/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py35,py36,py37,py38}-beam{22,23,24},docs,manifest,check-formatting,lint
+envlist = {py36,py37,py38}-beam{22,23,24},docs,manifest,check-formatting,lint
 
 [testenv]
 setenv =
@@ -10,8 +10,6 @@ install_command = python -m pip install {opts} {packages}
 deps =
     {toxinidir}/../core
     {toxinidir}/../lib
-    ; numpy 1.19+ does not support py3.5 (dependency via apache-beam)
-    py35: numpy<1.19
     ; apache-beam is already installed from above, but there's no way to
     ; dynamically edit setup.py in a decent way to update version dep
     beam22: apache-beam[gcp]>=2.22.0,<2.23.0
@@ -104,7 +102,6 @@ filterwarnings =
 ; will inherently run all beam versions in `envlist` per py version
 [gh-actions]
 python =
-    3.5: py35
     3.6: py36, docs, manifest, check-formatting,lint
     3.7: py37
     3.8: py38

--- a/integration/audio-spectrograms/Dockerfile
+++ b/integration/audio-spectrograms/Dockerfile
@@ -31,4 +31,4 @@ COPY __init__.py \
 
 ARG KLIO_CONFIG=klio-job.yaml
 COPY $KLIO_CONFIG /usr/src/config/.effective-klio-job.yaml
-RUN pip install .
+RUN pip install . --use-feature=2020-resolver

--- a/integration/batch-modular-default/Dockerfile
+++ b/integration/batch-modular-default/Dockerfile
@@ -27,4 +27,4 @@ COPY __init__.py \
 
 ARG KLIO_CONFIG=klio-job.yaml
 COPY $KLIO_CONFIG /usr/src/config/.effective-klio-job.yaml
-RUN pip install .
+RUN pip install . --use-feature=2020-resolver

--- a/integration/multi-event-input-batch/Dockerfile
+++ b/integration/multi-event-input-batch/Dockerfile
@@ -27,4 +27,4 @@ COPY __init__.py \
 
 ARG KLIO_CONFIG=klio-job.yaml
 COPY $KLIO_CONFIG /usr/src/config/.effective-klio-job.yaml
-RUN pip install .
+RUN pip install . --use-feature=2020-resolver

--- a/integration/read-bq-write-bq/Dockerfile
+++ b/integration/read-bq-write-bq/Dockerfile
@@ -26,4 +26,4 @@ COPY __init__.py \
 
 ARG KLIO_CONFIG=klio-job.yaml
 COPY $KLIO_CONFIG /usr/src/config/.effective-klio-job.yaml
-RUN pip install .
+RUN pip install . --use-feature=2020-resolver

--- a/integration/read-file-write-file/Dockerfile
+++ b/integration/read-file-write-file/Dockerfile
@@ -27,4 +27,4 @@ COPY __init__.py \
 
 ARG KLIO_CONFIG=klio-job.yaml
 COPY $KLIO_CONFIG /usr/src/config/.effective-klio-job.yaml
-RUN pip install .
+RUN pip install . --use-feature=2020-resolver

--- a/integration/read-file/Dockerfile
+++ b/integration/read-file/Dockerfile
@@ -27,4 +27,4 @@ COPY __init__.py \
 
 ARG KLIO_CONFIG=klio-job.yaml
 COPY $KLIO_CONFIG /usr/src/config/.effective-klio-job.yaml
-RUN pip install .
+RUN pip install . --use-feature=2020-resolver

--- a/integration/scripts/tox_commands.sh
+++ b/integration/scripts/tox_commands.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash +x
+#
+# Copyright 2020 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# KLIO_TEST_DIR & TOX_ENV_DIR need to be set (which is when running via tox)
+
+TOX_ENV_BIN_DIR=${TOX_ENV_DIR}/bin
+
+${TOX_ENV_BIN_DIR}/klio image build -j ${KLIO_TEST_DIR} --image-tag ${KLIO_TEST_DIR}
+${TOX_ENV_BIN_DIR}/klio job test -j ${KLIO_TEST_DIR} --image-tag ${KLIO_TEST_DIR} -- tests
+${TOX_ENV_BIN_DIR}/klio job run -j ${KLIO_TEST_DIR} --image-tag ${KLIO_TEST_DIR} --direct-runner 2>&1 | tee ${KLIO_TEST_DIR}/job_output.log
+
+if [ -f "${KLIO_TEST_DIR}/integration_test.py" ];
+  then python ${KLIO_TEST_DIR}/integration_test.py ;
+fi

--- a/integration/scripts/tox_commands_post.sh
+++ b/integration/scripts/tox_commands_post.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash +x
+#
+# Copyright 2020 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# KLIO_TEST_DIR needs to be set (which is when running via tox)
+
+if [ -f "${KLIO_TEST_DIR}/it/after.py" ];
+  then python ${KLIO_TEST_DIR}/it/after.py;
+fi
+
+rm -rf ${KLIO_TEST_DIR}/core
+rm -rf ${KLIO_TEST_DIR}/lib
+rm -rf ${KLIO_TEST_DIR}/exec
+rm -rf ${KLIO_TEST_DIR}/audio
+rm -rf ${KLIO_TEST_DIR}/job_output.log

--- a/integration/scripts/tox_commands_pre.sh
+++ b/integration/scripts/tox_commands_pre.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash +x
+#
+# Copyright 2020 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# KLIO_TEST_DIR needs to be set (which is when running via tox)
+
+# -r recursive, -p preserve perms
+rsync -rp ../core/src ${KLIO_TEST_DIR}/core
+rsync -rp ../core/setup.py ${KLIO_TEST_DIR}/core/setup.py
+# Need to copy over package's README.rst as it's needed to build it
+rsync -rp ../core/README.rst ${KLIO_TEST_DIR}/core/README.rst
+
+rsync -rp ../lib/src ${KLIO_TEST_DIR}/lib
+rsync -rp ../lib/setup.py ${KLIO_TEST_DIR}/lib/setup.py
+# Need to copy over package's README.rst as it's needed to build it
+rsync -rp ../lib/README.rst ${KLIO_TEST_DIR}/lib/README.rst
+
+rsync -rp ../exec/src ${KLIO_TEST_DIR}/exec
+rsync -rp ../exec/setup.py ${KLIO_TEST_DIR}/exec/setup.py
+# Need to copy over package's README.rst as it's needed to build it
+rsync -rp ../exec/README.rst ${KLIO_TEST_DIR}/exec/README.rst
+
+rsync -rp ../audio/src ${KLIO_TEST_DIR}/audio
+rsync -rp ../audio/setup.py ${KLIO_TEST_DIR}/audio/setup.py
+# Need to copy over package's README.rst as it's needed to build it
+rsync -rp ../audio/README.rst ${KLIO_TEST_DIR}/audio/README.rst
+
+if [ -f "${KLIO_TEST_DIR}/it/test-requirements.txt" ];
+  then pip install -r ${KLIO_TEST_DIR}/it/test-requirements.txt;
+fi
+if [ -f "${KLIO_TEST_DIR}/it/before.py" ];
+  then python ${KLIO_TEST_DIR}/it/before.py;
+fi

--- a/integration/scripts/tox_commands_pre.sh
+++ b/integration/scripts/tox_commands_pre.sh
@@ -38,7 +38,7 @@ rsync -rp ../audio/setup.py ${KLIO_TEST_DIR}/audio/setup.py
 rsync -rp ../audio/README.rst ${KLIO_TEST_DIR}/audio/README.rst
 
 if [ -f "${KLIO_TEST_DIR}/it/test-requirements.txt" ];
-  then pip install -r ${KLIO_TEST_DIR}/it/test-requirements.txt;
+  then pip install -r ${KLIO_TEST_DIR}/it/test-requirements.txt --use-feature=2020-resolver;
 fi
 if [ -f "${KLIO_TEST_DIR}/it/before.py" ];
   then python ${KLIO_TEST_DIR}/it/before.py;

--- a/integration/tox.ini
+++ b/integration/tox.ini
@@ -13,7 +13,7 @@ setenv =
 ; Define separate env dirs, otherwise will not be able to run more that one
 ; integration test at a time (particularly on tingle)
 envdir = {toxworkdir}/{env:KLIO_TEST_DIR}/{envname}
-install_command = python -m pip install {opts} {packages} --pre
+install_command = python -m pip install {opts} {packages} --use-feature=2020-resolver
 whitelist_externals =
     rsync
     rm

--- a/integration/tox.ini
+++ b/integration/tox.ini
@@ -24,12 +24,16 @@ commands_pre =
     ; -r recursive, -p preserve perms
     rsync -rp {toxinidir}/../core/src {env:KLIO_TEST_DIR}/core
     rsync -rp {toxinidir}/../core/setup.py {env:KLIO_TEST_DIR}/core/setup.py
+    rsync -rp {toxinidir}/../core/README.rst {env:KLIO_TEST_DIR}/core/README.rst
     rsync -rp {toxinidir}/../lib/src {env:KLIO_TEST_DIR}/lib
     rsync -rp {toxinidir}/../lib/setup.py {env:KLIO_TEST_DIR}/lib/setup.py
+    rsync -rp {toxinidir}/../lib/README.rst {env:KLIO_TEST_DIR}/lib/README.rst
     rsync -rp {toxinidir}/../exec/src {env:KLIO_TEST_DIR}/exec
     rsync -rp {toxinidir}/../exec/setup.py {env:KLIO_TEST_DIR}/exec/setup.py
+    rsync -rp {toxinidir}/../exec/README.rst {env:KLIO_TEST_DIR}/exec/README.rst
     rsync -rp {toxinidir}/../audio/src {env:KLIO_TEST_DIR}/audio
     rsync -rp {toxinidir}/../audio/setup.py {env:KLIO_TEST_DIR}/audio/setup.py
+    rsync -rp {toxinidir}/../audio/README.rst {env:KLIO_TEST_DIR}/audio/README.rst
     /bin/bash -c 'if [ -f "{env:KLIO_TEST_DIR}/it/test-requirements.txt" ]; then pip install -r {env:KLIO_TEST_DIR}/it/test-requirements.txt ; fi'
     /bin/bash -c 'if [ -f "{env:KLIO_TEST_DIR}/it/before.py" ]; then python {env:KLIO_TEST_DIR}/it/before.py; fi'
 commands =

--- a/integration/tox.ini
+++ b/integration/tox.ini
@@ -21,34 +21,11 @@ deps =
   {toxinidir}/../core
   {toxinidir}/../cli
 commands_pre =
-    ; -r recursive, -p preserve perms
-    rsync -rp {toxinidir}/../core/src {env:KLIO_TEST_DIR}/core
-    rsync -rp {toxinidir}/../core/setup.py {env:KLIO_TEST_DIR}/core/setup.py
-    rsync -rp {toxinidir}/../core/README.rst {env:KLIO_TEST_DIR}/core/README.rst
-    rsync -rp {toxinidir}/../lib/src {env:KLIO_TEST_DIR}/lib
-    rsync -rp {toxinidir}/../lib/setup.py {env:KLIO_TEST_DIR}/lib/setup.py
-    rsync -rp {toxinidir}/../lib/README.rst {env:KLIO_TEST_DIR}/lib/README.rst
-    rsync -rp {toxinidir}/../exec/src {env:KLIO_TEST_DIR}/exec
-    rsync -rp {toxinidir}/../exec/setup.py {env:KLIO_TEST_DIR}/exec/setup.py
-    rsync -rp {toxinidir}/../exec/README.rst {env:KLIO_TEST_DIR}/exec/README.rst
-    rsync -rp {toxinidir}/../audio/src {env:KLIO_TEST_DIR}/audio
-    rsync -rp {toxinidir}/../audio/setup.py {env:KLIO_TEST_DIR}/audio/setup.py
-    rsync -rp {toxinidir}/../audio/README.rst {env:KLIO_TEST_DIR}/audio/README.rst
-    /bin/bash -c 'if [ -f "{env:KLIO_TEST_DIR}/it/test-requirements.txt" ]; then pip install -r {env:KLIO_TEST_DIR}/it/test-requirements.txt ; fi'
-    /bin/bash -c 'if [ -f "{env:KLIO_TEST_DIR}/it/before.py" ]; then python {env:KLIO_TEST_DIR}/it/before.py; fi'
+    /bin/bash {toxinidir}/scripts/tox_commands_pre.sh
 commands =
-    {envbindir}/klio image build -j {env:KLIO_TEST_DIR} --image-tag {env:KLIO_TEST_DIR}
-    {envbindir}/klio job test -j {env:KLIO_TEST_DIR} --image-tag {env:KLIO_TEST_DIR} -- tests
-    /bin/bash -c '{envbindir}/klio job run -j {env:KLIO_TEST_DIR} --image-tag {env:KLIO_TEST_DIR} --direct-runner 2>&1 | tee {env:KLIO_TEST_DIR}/job_output.log'
-    /bin/bash -c 'if [ -f "{env:KLIO_TEST_DIR}/integration_test.py" ]; then python {env:KLIO_TEST_DIR}/integration_test.py ; fi'
-
+    /bin/bash {toxinidir}/scripts/tox_commands.sh
 commands_post =
-    /bin/bash -c 'if [ -f "{env:KLIO_TEST_DIR}/it/after.py" ]; then python {env:KLIO_TEST_DIR}/it/after.py; fi'
-    rm -rf {env:KLIO_TEST_DIR}/core
-    rm -rf {env:KLIO_TEST_DIR}/lib
-    rm -rf {env:KLIO_TEST_DIR}/exec
-    rm -rf {env:KLIO_TEST_DIR}/audio
-    rm -rf {env:KLIO_TEST_DIR}/job_output.log
+    /bin/bash {toxinidir}/scripts/tox_commands_post.sh
 
 ; required for mapping envs -> github runtimes
 [gh-actions]

--- a/lib/README.rst
+++ b/lib/README.rst
@@ -13,5 +13,5 @@ The ``klio`` Library
 
 The library for implementing Klio-ified Apache Beam transforms with `decorators <https://docs.klio.io/en/latest/userguide/pipeline/utilities.html>`_, `helper transforms <https://docs.klio.io/en/latest/userguide/pipeline/transforms.html>`_, and leverage Klio's `message-handling logic <https://docs.klio.io/en/latest/userguide/pipeline/message.html>`_.
 
-As the ``klio`` library is not meant to be installed directly, check out the `installation guide <https://docs.klio.io/en/latest/quickstart/installation.html>`_ for how to setup installation.
+As the ``klio`` library is **not** meant to be installed directly, check out the `installation guide <https://docs.klio.io/en/latest/quickstart/installation.html>`_ for how to setup installation.
 There is also the `user guide <https://docs.klio.io/en/latest/userguide/index.html>`_ and the `API documentation <https://docs.klio.io/en/latest/reference/lib/index.html>`_ for more information.

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -69,6 +69,7 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: Implementation :: CPython",
+    "License :: OSI Approved :: Apache Software License",
 ]
 META_FILE = read(META_PATH)
 INSTALL_REQUIRES = [

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -70,7 +70,21 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: Implementation :: CPython",
     "License :: OSI Approved :: Apache Software License",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Multimedia",
+    "Topic :: Multimedia :: Graphics",
+    "Topic :: Multimedia :: Sound/Audio",
+    "Topic :: Multimedia :: Video",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Image Processing",
 ]
+KEYWORDS = ["klio", "apache", "beam", "audio"]
+PROJECT_URLS = {
+    "Documentation": "https://docs.klio.io",
+    "Bug Tracker": "https://github.com/spotify/klio/issues",
+    "Source Code": "https://github.com/spotify/klio"
+}
 META_FILE = read(META_PATH)
 INSTALL_REQUIRES = [
     # 2.22 added DirectRunner support for `DoFn.setup`
@@ -103,6 +117,8 @@ setup(
     version=find_meta("version"),
     description=find_meta("description"),
     url=find_meta("uri"),
+    project_urls=PROJECT_URLS,
+    keywords=KEYWORDS,
     author=find_meta("author"),
     author_email=find_meta("email"),
     maintainer=find_meta("author"),

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -65,7 +65,6 @@ CLASSIFIERS = [
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
@@ -95,8 +94,8 @@ EXTRAS_REQUIRE = {
 EXTRAS_REQUIRE["dev"] = (
     EXTRAS_REQUIRE["docs"] + EXTRAS_REQUIRE["tests"] + ["bumpversion", "wheel"]
 )
-# support 3.5, 3.6, 3.7, & 3.8, matching Beam's support
-PYTHON_REQUIRES = ">=3.5, <3.9"
+# support 3.6, 3.7, & 3.8, matching Beam's support
+PYTHON_REQUIRES = ">=3.6, <3.9"
 
 setup(
     name=NAME,

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -24,6 +24,7 @@ from setuptools import setup
 
 
 HERE = os.path.abspath(os.path.dirname(__file__))
+ROOT_DIR = os.path.abspath(os.path.join(HERE, os.path.pardir))
 
 
 #####
@@ -50,6 +51,69 @@ def find_meta(meta):
     if meta_match:
         return meta_match.group(1)
     raise RuntimeError("Unable to find __{meta}__ string.".format(meta=meta))
+
+
+def get_recent_changelog(filename):
+    """Grab the entry for the latest release."""
+    contents = read(filename).split("\n")
+    # Skip the title (first two lines)
+    contents = contents[2:]
+
+    # Find the latest release
+    start_line, end_line = None, None
+    for i, line in enumerate(contents):
+        # if we've found the start & end, we're done
+        if all([start_line, end_line]):
+            break
+
+        # 4 dashes are a horizontal line in rST, so look for headers with 5+
+        if line.startswith("-----"):
+            if start_line is None:
+                start_line = i - 1
+                continue
+            if end_line is None:
+                end_line = i - 1
+                continue
+
+    recent_log_lines = contents[start_line:end_line]
+    recent_log = "\n".join(recent_log_lines)
+    return recent_log
+
+
+def get_main_readme_intro():
+    """Grab the intro from the README from the root of the project."""
+    readme_path = os.path.join(ROOT_DIR, "README.rst")
+    contents = read(readme_path).split(".. start-long-desc")[1:]
+    return "\n".join(contents)
+
+
+def get_long_description(package_dir):
+    """Generate the long description from the README and changelog."""
+    cl_base_path = f"reference/{package_dir}/changelog"
+    cl_file_path = os.path.join(ROOT_DIR, f"docs/src/{cl_base_path}.rst")
+    cl_url = f"{PROJECT_URLS['Documentation']}/en/latest/{cl_base_path}.html"
+
+    # When tox builds the library, it loses where the ROOT_DIR is; this
+    # is also a problem with our integration tests. So we'll just ignore
+    # if there's an error and continue on
+    main_readme, recent_changelog = "", ""
+    try:
+        main_readme = get_main_readme_intro()
+        recent_changelog = get_recent_changelog(cl_file_path)
+    except Exception:
+        pass
+
+    desc = (
+        read("README.rst")
+        + "\n"
+        + main_readme
+        + "\n"
+        + "Release Information\n"
+        + "===================\n\n"
+        + recent_changelog
+        + f"\n\n`Full Changelog <{cl_url}>`_.\n\n"
+    )
+    return desc
 
 
 #####
@@ -116,6 +180,8 @@ setup(
     name=NAME,
     version=find_meta("version"),
     description=find_meta("description"),
+    long_description=get_long_description("executor"),
+    long_description_content_type="text/x-rst",
     url=find_meta("uri"),
     project_urls=PROJECT_URLS,
     keywords=KEYWORDS,

--- a/lib/tox.ini
+++ b/lib/tox.ini
@@ -1,13 +1,11 @@
 [tox]
-envlist = {py35,py36,py37,py38}-beam{22,23,24},docs,manifest,check-formatting,lint
+envlist = {py36,py37,py38}-beam{22,23,24},docs,manifest,check-formatting,lint
 
 [testenv]
 install_command = python -m pip install {opts} {packages}
 extras = tests
 deps =
     {toxinidir}/../core
-    ; numpy 1.19+ does not support py3.5 (dependency via apache-beam)
-    py35: numpy<1.19
     beam22: apache-beam[gcp]>=2.22.0,<2.23.0
     beam23: apache-beam[gcp]>=2.23.0,<2.24.0
     beam24: apache-beam[gcp]>=2.24.0,<2.25.0
@@ -94,7 +92,6 @@ filterwarnings =
 ; will inherently run all beam versions in `envlist` per py version
 [gh-actions]
 python =
-    3.5: py35
     3.6: py36, docs, manifest, check-formatting,lint
     3.7: py37
     3.8: py38


### PR DESCRIPTION
<!--- Describe your changes 

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

Killing a few birds here in one PR:

* remove py35 support (from testing matrices & from packaging)
* add/update packaging classifiers (license, topics) and other packaging metadata elements
* add long descriptions to each package (which gets populated on each package's PyPI project page)

<!--- How have you tested this?
Some valid responses are:

* "I have included unit tests" 
* "I have included integration tests"
* "I successfully ran my jobs with this code"

-->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ ] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
