### PR TITLE
[docs] Add BigQuery event inputs to user guide

### DIFF
--- a/docs/src/userguide/config/event_config.rst
+++ b/docs/src/userguide/config/event_config.rst
@@ -17,17 +17,17 @@ Consuming KlioMessages from `Google Pub/Sub`_ is supported for all runners.
 
 Example configuration for `Google Pub/Sub`_:
 
-    .. code-block:: yaml
+.. code-block:: yaml
 
-        name: my-cool-job
-        pipeline_options:
-          streaming: True
-        job_config:
-          events:
+    name: my-cool-job
+    pipeline_options:
+      streaming: True
+    job_config:
+        events:
             inputs:
-              - type: pubsub
-                topic: my-parent-output-topic
-                subscription: my-input-subscription
+                - type: pubsub
+                  topic: my-parent-output-topic
+                  subscription: my-input-subscription
 
 .. option:: job_config.events.inputs[].type
 
@@ -100,14 +100,14 @@ Custom
 
 Example configuration for a custom event input that is not supported by Klio:
 
-    .. code-block:: yaml
+.. code-block:: yaml
 
-        name: my-cool-job
-        job_config:
-          events:
+    name: my-cool-job
+    job_config:
+        events:
             inputs:
-              - type: custom
-                some_key: some_value
+                - type: custom
+                  some_key: some_value
 
 .. option:: job_config.events.inputs[].type
 
@@ -312,16 +312,16 @@ Publishing KlioMessages to `Google Pub/Sub`_ is supported for all runners.
 
 Example configuration for `Google Pub/Sub`_:
 
-    .. code-block:: yaml
+.. code-block:: yaml
 
-        name: my-cool-job
-        pipeline_options:
-          streaming: True
-        job_config:
-          events:
-            outputs:
-              - type: pubsub
-                topic: my-output-topic
+    name: my-cool-job
+    pipeline_options:
+        streaming: True
+    job_config:
+        events:
+        outputs:
+            - type: pubsub
+              topic: my-output-topic
 
 .. option:: job_config.events.outputs[].type
 
@@ -352,14 +352,14 @@ Custom
 
 Example configuration for a custom event input that is not supported by Klio:
 
-    .. code-block:: yaml
+.. code-block:: yaml
 
-        name: my-cool-job
-        job_config:
-          events:
+    name: my-cool-job
+    job_config:
+        events:
             outputs:
-              - type: custom
-                some_key: some_value
+            - type: custom
+              some_key: some_value
 
 .. option:: job_config.events.outputs[].type
 

--- a/docs/src/userguide/config/event_config.rst
+++ b/docs/src/userguide/config/event_config.rst
@@ -126,12 +126,182 @@ Example configuration for a custom event input that is not supported by Klio:
 
     Any arbitrary key-value pairs for custom event input configuration specific to a job.
 
+.. _event-config-bigquery:
 
-.. todo:: document supported batch event inputs
+Google BigQuery
+^^^^^^^^^^^^^^^
 
+*Mode: Batch*
+
+Consuming KlioMessages from `Google BigQuery`_ is supported for all runners.
+
+Klio allows the user to specify events using either queries or columns from a table. Tables can be specified either though a table reference in the `table` field (e.g. ``'DATASET.TABLE'`` or ``'PROJECT:DATASET.TABLE'``) or by filling in the fields for `project`, `dataset`, and `table`. If the columns representing the event input are not specified through the `columns` field, all columns from the table are returned.  Note that the user cannot specify both a `query` and a `table` (with its associated `project`, `dataset`, and `columns`); they are mutually exclusive.
+
+
+Example configuration for `Google BigQuery`_, by specifying a table:
+
+.. code-block:: yaml
+
+    name: my-cool-job
+    pipeline_options:
+        streaming: True
+    job_config:
+        events:
+            inputs:
+                - type: bq
+                columns:
+                - entity_id
+                dataset: bigquery_dataset
+                project: gcp_project
+                table: bigquery_table
+
+
+Example configuration for `Google BigQuery`_, by specifying a query in the BigQuery dialect:
+
+.. code-block:: yaml
+
+    name: my-cool-job
+    pipeline_options:
+        streaming: True
+    job_config:
+    events:
+        inputs:
+            - type: bq
+              query: |
+                  SELECT * FROM [gcp_project.bigquery_dataset.bigquery_table]
+
+.. option:: job_config.events.inputs[].type
+
+    Value: ``bq``
+
+    | **Runner**: Dataflow, Direct
+    | *Required*
+
+.. option:: job_config.events.inputs[].columns[]
+
+    Not applicable if ``query`` is specified.
+
+    A list of strings specifying the columns to read events from.
+    If only one column is provided, the value will be returned as a bytestring.
+    If no columns are specified (meaning that all columns are selected),
+    or if more than one column is specified,
+    the results including the column names will be serialized to a JSON bytestring,
+    e.g. ``'{"field1": "foo", "field2": bar"}'``.
+
+
+    | **Runner**: Dataflow, Direct
+    | *Optional*
+
+.. option:: job_config.events.inputs[].columns[].<column> STR
+
+    A column name in the table or query result used to build the event input from.
+
+    | **Runner**: Dataflow, Direct
+    | *Optional*
+
+.. option:: job_config.events.inputs[].table STR
+
+    Name of the table to use for event input.
+
+    The ID must contain only letters ``a-z``, ``A-Z``, numbers ``0-9``,
+    or underscores ``_``.
+
+    If dataset and query arguments are not specified,  then the table argument must
+    contain the entire table reference specified as:
+    ``'DATASET.TABLE'`` or ``'PROJECT:DATASET.TABLE'``.
+
+    | **Runner**: Dataflow, Direct
+    | *Required when using project, dataset, table, and columns to specify event inputs*
+
+.. option:: job_config.events.inputs[].dataset STR
+
+    Name of the event input table's dataset.
+
+    Ignored if the table reference is fully specified by the table argument or
+    if a query is specified.
+
+    | **Runner**: Dataflow, Direct
+    | *Required when using project, dataset, table, and columns to specify event inputs
+       and table reference does not include dataset*
+
+.. option:: job_config.events.inputs[].project STR
+
+    Name of the event input table's project.
+
+    Ignored if the table reference is fully specified by the table argument or
+    if a query is specified.
+
+    | **Runner**: Dataflow, Direct
+    | *Required when using project, dataset, table, and columns to specify event inputs
+       and table reference does not include project*
+
+.. option:: job_config.events.inputs[].query STR
+
+    Query string supplying the columns. Mutually exclusive with specifying the
+    ``table`` field.
+
+    | **Runner**: Dataflow, Direct
+    | *Required if project, dataset, table and columns were not used to specify event inputs*
+
+.. option:: job_config.events.inputs[].validate BOOL
+
+    If :data:`True`, various checks will be done when source
+    gets initialized (e.g., is table present?). This should be
+    :data:`True` for most scenarios in order to catch errors as early as
+    possible (pipeline construction instead of pipeline execution). It
+    should be :data:`False` if the table is created during pipeline
+    execution by a previous step. Defaults to :data:`True`.
+
+    | **Runner**: Dataflow, Direct
+    | *Optional*
+
+.. option:: job_config.events.inputs[].coder STR
+
+    A string representing the import path to a coder
+    for the table rows if serialized to disk.
+
+    If not specified, then the default coder is
+    :class:`~apache_beam.io.gcp.bigquery_tools.RowAsDictJsonCoder`,
+    which will interpret every line in a file as a JSON serialized
+    dictionary. This argument needs a value only in special cases when
+    returning table rows as dictionaries is not desirable.
+
+    | **Runner**: Dataflow, Direct
+    | *Optional*
+
+.. option:: job_config.events.inputs[].use_standard_sql BOOL
+
+    Specifies whether to use BigQuery's standard SQL
+    dialect for the query. The default value is :data:`False`.
+    If set to :data:`True`, the query will use BigQuery's updated SQL
+    dialect with improved standards compliance.
+    This parameter is ignored for table inputs.
+
+    | **Runner**: Dataflow, Direct
+    | *Optional*
+
+.. option:: job_config.events.inputs[].flatten_results BOOL
+
+    Flattens all nested and repeated fields in the query results.
+    The default value is :data:`True`.
+
+    | **Runner**: Dataflow, Direct
+    | *Optional*
+
+.. option:: job_config.events.inputs[].kms_key STR
+
+    Optional Cloud KMS key name for use when creating new tables.
+
+    | **Runner**: Dataflow, Direct
+    | *Optional*
+
+.. option:: job_config.events.inputs[].skip_klio_read BOOL
+
+    Inherited from :ref:`global event input config <skip-klio-read>`.
 
 Output
 ------
+
 
 Google Pub/Sub
 ^^^^^^^^^^^^^^
@@ -213,4 +383,5 @@ Example configuration for a custom event input that is not supported by Klio:
 
 
 .. _Google Pub/Sub: https://cloud.google.com/pubsub/docs
+.. _Google BigQuery: https://cloud.google.com/bigquery/docs
 

--- a/docs/src/userguide/io/index.rst
+++ b/docs/src/userguide/io/index.rst
@@ -148,6 +148,13 @@ to process.
 More information about configuring pub/sub can be found in the
 :ref:`event-config-pubsub` event config section.
 
+Google BigQuery
+^^^^^^^^^^^^^^^
+
+Only supported in batch mode.
+
+Klio supports BigQuery columns as event inputs. More information about configuring BigQuery table inputs can be found in the :ref:`event-config-bigquery` event config section.
+
 
 Data I/O
 --------

--- a/lib/src/klio/transforms/io.py
+++ b/lib/src/klio/transforms/io.py
@@ -183,77 +183,87 @@ class _KlioReadFromBigQueryMapper(object):
 # documentation will be shown, excluding our new parameter.
 class KlioReadFromBigQuery(beam.PTransform, _KlioTransformMixin):
     """Read data from BigQuery.
-      This PTransform uses a BigQuery export job to take a snapshot of the table
-      on GCS, and then reads from each produced file. File format is Avro by
-      default.
+
+    This PTransform uses a BigQuery export job to take a snapshot of the table
+    on GCS, and then reads from each produced file. File format is Avro by
+    default.
+
     Args:
-      table (str, callable, ValueProvider): The ID of the table, or a callable
-        that returns it. The ID must contain only letters ``a-z``, ``A-Z``,
-        numbers ``0-9``, or underscores ``_``. If dataset argument is
-        :data:`None` then the table argument must contain the entire table
-        reference specified as: ``'DATASET.TABLE'``
-        or ``'PROJECT:DATASET.TABLE'``. If it's a callable, it must receive one
-        argument representing an element to be written to BigQuery, and return
-        a TableReference, or a string table name as specified above.
-      dataset (str): The ID of the dataset containing this table or
-        :data:`None` if the table reference is specified entirely by the table
-        argument.
-      project (str): The ID of the project containing this table.
-      klio_message_columns (list): A list of fields (``str``) that should
-        be assigned to ``KlioMessage.data.element``.
+        table (str, callable, ValueProvider): The ID of the table, or a callable
+            that returns it. The ID must contain only letters ``a-z``, ``A-Z``,
+            numbers ``0-9``, or underscores ``_``. If dataset argument is
+            :data:`None` then the table argument must contain the entire table
+            reference specified as: ``'DATASET.TABLE'``
+            or ``'PROJECT:DATASET.TABLE'``.
+            If it's a callable, it must receive one argument representing an
+            element to be written to BigQuery, and return
+            a TableReference, or a string table name as specified above.
+        dataset (str): The ID of the dataset containing this table or
+            :data:`None` if the table reference is specified entirely by
+            the table argument.
+        project (str): The ID of the project containing this table.
+        klio_message_columns (list): A list of fields (``str``) that should
+            be assigned to ``KlioMessage.data.element``.
 
-        .. note::
+            .. note::
 
-            If more than one field is provided, the results including the
-            column names will be serialized to JSON before assigning to
-            ``KlioMessage.data.element``. (e.g. ``'{"field1": "foo",
-            "field2": bar"}'``). If only one field is provided, just the
-            value will be assigned to ``KlioMessage.data.element``.
+                If more than one field is provided, the results including the
+                column names will be serialized to JSON before assigning to
+                ``KlioMessage.data.element``. (e.g. ``'{"field1": "foo",
+                "field2": bar"}'``). If only one field is provided, just the
+                value will be assigned to ``KlioMessage.data.element``.
 
-      query (str, ValueProvider): A query to be used instead of arguments
-        table, dataset, and project.
-      validate (bool): If :data:`True`, various checks will be done when source
-        gets initialized (e.g., is table present?). This should be
-        :data:`True` for most scenarios in order to catch errors as early as
-        possible (pipeline construction instead of pipeline execution). It
-        should be :data:`False` if the table is created during pipeline
-        execution by a previous step.
-      coder (~apache_beam.coders.coders.Coder): The coder for the table
-        rows. If :data:`None`, then the default coder is
-        _JsonToDictCoder, which will interpret every row as a JSON
-        serialized dictionary.
-      use_standard_sql (bool): Specifies whether to use BigQuery's standard SQL
-        dialect for this query. The default value is :data:`False`.
-        If set to :data:`True`, the query will use BigQuery's updated SQL
-        dialect with improved standards compliance.
-        This parameter is ignored for table inputs.
-      flatten_results (bool): Flattens all nested and repeated fields in the
-        query results. The default value is :data:`True`.
-      kms_key (str): Optional Cloud KMS key name for use when creating new
-        temporary tables.
-      gcs_location (str, ValueProvider): The name of the Google Cloud Storage
-        bucket where the extracted table should be written as a string or
-        a :class:`~apache_beam.options.value_provider.ValueProvider`. If
-        :data:`None`, then the temp_location parameter is used.
-      bigquery_job_labels (dict): A dictionary with string labels to be passed
-        to BigQuery export and query jobs created by this transform. See:
-        https://cloud.google.com/bigquery/docs/reference/rest/v2/\
-                Job#JobConfiguration
-      use_json_exports (bool): By default, this transform works by exporting
-        BigQuery data into Avro files, and reading those files. With this
-        parameter, the transform will instead export to JSON files. JSON files
-        are slower to read due to their larger size.  When using JSON exports,
-        the BigQuery types for DATE, DATETIME, TIME, and TIMESTAMP will be
-        exported as strings. This behavior is consistent with BigQuerySource.
-        When using Avro exports, these fields will be exported as native Python
-        types (datetime.date, datetime.datetime, datetime.datetime,
-        and datetime.datetime respectively). Avro exports are recommended.
-        To learn more about BigQuery types, and Time-related type
-        representations, see: https://cloud.google.com/bigquery/docs/reference/\
-                standard-sql/data-types
-        To learn more about type conversions between BigQuery and Avro, see:
-        https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-avro\
-                #avro_conversions
+        query (str, ValueProvider): A query to be used instead of arguments
+            table, dataset, and project.
+        validate (bool): If :data:`True`, various checks will be done when
+            source gets initialized (e.g., is table present?).
+            This should be :data:`True` for most scenarios
+            in order to catch errors as early as possible
+            (pipeline construction instead of pipeline execution).
+            It should be :data:`False` if the table is created during pipeline
+            execution by a previous step.
+        coder (~apache_beam.coders.coders.Coder): The coder for the table
+            rows. If :data:`None`, then the default coder is
+            _JsonToDictCoder, which will interpret every row as a JSON
+            serialized dictionary.
+        use_standard_sql (bool): Specifies whether to use BigQuery's standard
+            SQL dialect for this query. The default value is :data:`False`.
+            If set to :data:`True`, the query will use BigQuery's updated SQL
+            dialect with improved standards compliance.
+            This parameter is ignored for table inputs.
+        flatten_results (bool): Flattens all nested and repeated fields in the
+            query results. The default value is :data:`True`.
+        kms_key (str): Optional Cloud KMS key name for use when creating new
+            temporary tables.
+        gcs_location (str, ValueProvider): The name of the Google Cloud Storage
+            bucket where the extracted table should be written as a string or
+            a :class:`~apache_beam.options.value_provider.ValueProvider`. If
+            :data:`None`, then the temp_location parameter is used.
+        bigquery_job_labels (dict): A dictionary with string labels to be passed
+            to BigQuery export and query jobs created by this transform. See:
+            https://cloud.google.com/bigquery/docs/reference/rest/v2/\
+Job#JobConfiguration
+        use_json_exports (bool): By default, this transform works by exporting
+            BigQuery data into Avro files, and reading those files. With this
+            parameter, the transform will instead export to JSON files.
+            JSON files are slower to read due to their larger size.
+            When using JSON exports,
+            the BigQuery types for DATE, DATETIME, TIME, and TIMESTAMP will be
+            exported as strings.
+
+            This behavior is consistent with BigQuerySource.
+            When using Avro exports,
+            these fields will be exported as native Python
+            types (datetime.date, datetime.datetime, datetime.datetime,
+            and datetime.datetime respectively). Avro exports are recommended.
+            To learn more about BigQuery types, and Time-related type
+            representations,
+            see:
+            https://cloud.google.com/bigquery/docs/reference/standard-sql/\
+data-types
+            To learn more about type conversions between BigQuery and Avro, see:
+            https://cloud.google.com/bigquery/docs/loading-data-cloud-\
+storage-avro#avro_conversions
      """
 
     def __init__(self, *args, klio_message_columns=None, **kwargs):


### PR DESCRIPTION
Document using BigQuery as an event input source, making sure to cover the fact that if only one `column` is specified,   the input value will be returned as a plain bytestring, while specifying either no or multiple column fields will result in a JSON serialized bytestring containing the contents of the row. 

Update: Also includes a short indentation fix for the `KlioReadFromBigQuery` docstring - without this fix, we encounter a `sphinx` build error: 
```docstring of klio.transforms.io.KlioReadFromBigQuery:5:Definition list ends without a blank line; unexpected unindent.```

<!--- How have you tested this?
Ran some integration tests to check syntax.
-->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ x] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ x] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ x] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
