### PR TITLE
[cli] Remove checks for topic/subscription in event input/output when event types are not pubsub

### DIFF
--- a/cli/src/klio_cli/commands/job/verify.py
+++ b/cli/src/klio_cli/commands/job/verify.py
@@ -329,7 +329,10 @@ class VerifyJob(object):
 
         logging.info("Verifying your event outputs...")
 
-        for output in event_outputs:
+        pubsub_event_outputs = [
+            _i for _i in event_outputs if _i.name == "pubsub"
+        ]
+        for output in pubsub_event_outputs:
             output_topic = output.topic
 
             if output_topic is not None:
@@ -339,11 +342,20 @@ class VerifyJob(object):
             else:
                 logging.error("There is no topic for {}".format(output))
 
-        logging.info(
-            "You have {} unverified output buckets and {} unverified output "
-            "topics".format(unverified_bucket_count, unverified_topic_count)
-        )
-
+        if pubsub_event_outputs:
+            logging.info(
+                "You have {} unverified output buckets "
+                "and {} unverified output "
+                "topics".format(
+                    unverified_bucket_count, unverified_topic_count
+                )
+            )
+        else:
+            logging.info(
+                "You have {} unverified output buckets".format(
+                    unverified_bucket_count
+                )
+            )
         if unverified_bucket_count + unverified_topic_count == 0:
             return True
         return False

--- a/cli/src/klio_cli/commands/job/verify.py
+++ b/cli/src/klio_cli/commands/job/verify.py
@@ -255,7 +255,10 @@ class VerifyJob(object):
 
         logging.info("Verifying your event inputs...")
 
-        for _input in event_inputs:
+        pubsub_event_inputs = [
+            _i for _i in event_inputs if _i.name == "pubsub"
+        ]
+        for _input in pubsub_event_inputs:
             input_topic = _input.topic
             input_subscription = _input.subscription
 
@@ -277,14 +280,21 @@ class VerifyJob(object):
                     )
                 )
 
-        logging.info(
-            "You have {} unverified input buckets, {} unverified input "
-            "topics and {} unverified input subscriptions".format(
-                unverified_bucket_count,
-                unverified_topic_count,
-                unverified_sub_count,
+        if len(pubsub_event_inputs):
+            logging.info(
+                "You have {} unverified input buckets, {} unverified input "
+                "topics and {} unverified input subscriptions".format(
+                    unverified_bucket_count,
+                    unverified_topic_count,
+                    unverified_sub_count,
+                )
             )
-        )
+        else:
+            logging.info(
+                "You have {} unverified input buckets".format(
+                    unverified_bucket_count,
+                )
+            )
 
         if (
             unverified_bucket_count


### PR DESCRIPTION
Currently the `klio job verify` command has functionality for verifying that the job's inputs and outputs are correctly configured. This is all currently hard-coded to assume that event-I/O is pubsub and data I/O is GCS.

Going forward these checks need to be more modular so that the checks performed match the actual type of I/O.

For now we should not error out on other types of solutions.

<!--- How have you tested this?
I have included unit tests and tested different configuration files by hand.

-->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ x] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ x] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ x] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
