### PR TITLE
Bumpversion klio-0.2.1 -> klio-0.2.1.post

### DIFF
--- a/docs/src/reference/lib/changelog.rst
+++ b/docs/src/reference/lib/changelog.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+0.2.1.post (2020-11-30)
+------------------------
+
+Fixed
+*****
+
+* Requires klio-core<0.2.1,>=0.2.0 to prevent useage of 0.2.1 until dependent code is released
+* Klio lib requires changes not yet released in klio-core
+
 0.2.1 (2020-11-24)
 ------------------------
 

--- a/lib/setup.cfg
+++ b/lib/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.1
+current_version = 0.2.1.post1
 commit = True
 tag = True
 tag_name = lib-{new_version}

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -154,7 +154,7 @@ INSTALL_REQUIRES = [
     # 2.22 added DirectRunner support for `DoFn.setup`
     "apache-beam[gcp]>2.21.0",
     "google-api-python-client",
-    "klio-core>=0.2.0",
+    "klio-core<0.2.1,>=0.2.0",
     "protobuf",
     "psutil",
     "pyyaml",

--- a/lib/src/klio/__init__.py
+++ b/lib/src/klio/__init__.py
@@ -14,7 +14,7 @@
 #
 
 __author__ = "The klio developers"
-__version__ = "0.2.1"
+__version__ = "0.2.1.post1"
 __email__ = "opensource+klio@spotify.com"
 __description__ = "Conventions for Python + Apache Beam "
 __uri__ = "https://github.com/spotify/klio"


### PR DESCRIPTION
## Description

Solves this issue here:
```
 File "/usr/local/lib/python3.6/site-packages/apache_beam/transforms/userstate.py", line 281, in validate_stateful_dofn
    all_state_specs, all_timer_specs = get_dofn_specs(dofn)
  File "/usr/local/lib/python3.6/site-packages/apache_beam/transforms/userstate.py", line 250, in get_dofn_specs
    if not isinstance(getattr(dofn, method_name, None), types.MethodType):
  File "/usr/local/lib/python3.6/site-packages/klio/transforms/_helpers.py", line 169, in _data_config
    if len(self._klio.config.job_config.data.inputs) > 1:
  File "/usr/local/lib/python3.6/site-packages/klio/transforms/core.py", line 114, in config
    return RunConfig.get()
  File "/usr/local/lib/python3.6/site-packages/klio/transforms/core.py", line 34, in get
    "Attempt to access RunConfig before it was set. This likely"
Exception: Attempt to access RunConfig before it was set. This likely means something was imported before RunConfig was set.
```

That was arising after klio-0.2.1 was released since klio-lib changes require the latest code from core and exec. In order to prevent users from using klio-0.2.1 before new releases of core is released this 0.2.1.post1 will require a future klio-core

## Testing
No logic changes just bumping a version

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [x] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [x] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [x] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
