### PR TITLE
[docs] De-emphasize references to FnAPI

### DIFF
--- a/docs/src/faqs/index.rst
+++ b/docs/src/faqs/index.rst
@@ -27,6 +27,8 @@ FAQs
     custom_proto_def
     dags_in_klio
     migrate_from_fnapi
+    migrate_from_setup
+    setup_packaging
 
 
 General
@@ -76,3 +78,5 @@ Technical
     publish_kmsgs_from_non_klio_job
     custom_proto_def
     migrate_from_fnapi
+    migrate_from_setup
+    setup_packaging

--- a/docs/src/faqs/migrate_from_fnapi.rst
+++ b/docs/src/faqs/migrate_from_fnapi.rst
@@ -1,3 +1,5 @@
+.. _migrate-from-fnapi:
+
 How Do I Migrate from FnAPI to ``setup.py``?
 ============================================
 

--- a/docs/src/faqs/migrate_from_setup.rst
+++ b/docs/src/faqs/migrate_from_setup.rst
@@ -1,0 +1,170 @@
+.. _migrate-from-setup:
+
+How Do I Migrate from ``setup.py`` to FnAPI?
+============================================
+
+
+The FnAPI (pronounced "fun API") is what allows Klio to use custom Docker images
+on Dataflow workers.
+However, it's still considered experimental.
+The fully-supported way to run a job that has dependencies
+(both Python and OS-level dependencies) is via `setup.py <https://beam.apache.org/documentation/
+sdks/python-pipeline-dependencies>`_.
+
+Below describes what changes need to be made to an existing job to move from
+``setup.py`` to FnAPI.
+
+Creating a new Klio job that does not use ``setup.py`` from the start via:
+
+.. code-block:: console
+
+   $ klio job create --use-fnapi true
+
+
+Note that this command above will create a job that uses FnAPI for packaging - you will not
+need to follow any of the steps below. The steps below convert a job that uses ``setup.py`` for
+packaging to one that uses FnAPI.
+
+Required Setup/Changes
+----------------------
+
+Update: ``klio-job.yaml``
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Under ``pipeline_options``:
+
+1. **DELETE** the key ``setup_file``.
+2. **ADD** the list key ``experiments`` under ``pipeline_options``, containing the item ``beam_fn_api``. Using the ``beam_fn_api`` experiment in conjunction with setting the ``worker_harness_container_image`` tells Klio and Dataflow to use FnAPI rather than the setup file to package the job.
+
+.. collapsible:: Minimal Example ``klio-job.yaml``
+
+    .. code-block:: yaml
+
+        job_name: my-job
+        pipeline_options:
+            # NOTE! setup_file is absent
+            experiments:
+                - beam_fn_api
+            worker_harness_container_image: gcr.io/my-project/my-job-image
+            runner: DataflowRunner
+            # <-- snip -->
+
+
+Update: ``Dockerfile``
+^^^^^^^^^^^^^^^^^^^^^^
+
+Required Changes
+~~~~~~~~~~~~~~~~
+
+
+1. **MOVE** the ``COPY`` line that copies ``job-requirements.txt`` into the image ahead of the rest of the lines that copy in Python files.
+
+2. **UPDATE**  ``RUN pip install .`` to ``RUN pip install -r job-requirements.txt``
+
+.. collapsible:: Why is this needed?
+
+    We now install dependencies directly on the worker image.
+
+3. **MOVE**  ``RUN pip install -r job-requirements.txt`` to the line right after the one from step 1, that copies in ``job-requirements.txt``.
+
+.. collapsible:: Why is this needed?
+
+    This is done as an image build optimization - since your job's Python files are more likely to change than the dependencies in `job-requirements.txt`, it is more efficient install them first.
+
+4. **ADD** any system-level dependencies using ``RUN apt-get update && apt-get install ...``.
+
+.. collapsible:: Why is this needed?
+
+    These dependencies were previously installed through specifying them in ``setup.py`` and running ``pip install .``. They now need to be installed directly on the worker image for your Klio job to use.
+
+.. collapsible:: Example of Required Changes
+
+    .. code-block:: diff
+
+        FROM apache/beam_python3.6_sdk:2.24.0
+
+        WORKDIR /usr/src/app
+
+        ENV GOOGLE_CLOUD_PROJECT my-project \
+            PYTHONPATH /usr/src/app
+
+        + RUN apt-get update && apt-get install my-package
+
+        RUN pip install --upgrade pip setuptools
+
+        + COPY job-requirements.txt job-requirements.txt
+        + RUN pip install -r job-requirements.txt
+
+        COPY __init__.py \
+            run.py \
+            transforms.py \
+        -   job-requirements.txt \
+            /usr/src/app/
+
+        - RUN pip install .
+
+Suggested Changes
+~~~~~~~~~~~~~~~~~
+
+The following is a collection of suggested changes to optimize Docker builds by removing no longer used layers and to closer mimic the runtime environment on Dataflow.
+
+.. caution::
+
+    **Most of these changes are incompatible with using setup.py.**
+
+    The following changes will break your job if you return to using ``setup.py`` to package your dependencies. If you choose to switch back, simply undo these deletions.
+
+* **DELETE** lines copying ``MANIFEST.in`` and ``setup.py`` since they are no longer used. If you remove those files from your job directory without also editing your the copy commands out of your Dockerfile, your build will break.
+
+.. collapsible:: Example of Suggested Changes
+
+    .. code-block:: diff
+
+        FROM apache/beam_python3.6_sdk:2.24.0
+
+        WORKDIR /usr/src/app
+
+        ENV GOOGLE_CLOUD_PROJECT my-project \
+            PYTHONPATH /usr/src/app
+
+        RUN pip install --upgrade pip setuptools
+
+        COPY __init__.py \
+        -   setup.py \
+        -   MANIFEST.in \
+            klio-job.yaml \
+            run.py \
+            transforms.py \
+            job-requirements.txt \
+            /usr/src/app/
+
+        RUN pip install .
+
+.. collapsible:: Combined Example of Required & Suggested Changes
+
+    .. code-block:: diff
+
+        FROM apache/beam_python3.6_sdk:2.24.0
+
+        WORKDIR /usr/src/app
+
+        ENV GOOGLE_CLOUD_PROJECT my-project \
+            PYTHONPATH /usr/src/app
+
+        + RUN apt-get update && apt-get install my-package
+
+        RUN pip install --upgrade pip setuptools
+
+        + COPY job-requirements.txt job-requirements.txt
+        + RUN pip install -r job-requirements.txt
+
+        COPY __init__.py \
+        -   setup.py \
+        -   MANIFEST.in \
+            klio-job.yaml \
+            run.py \
+            transforms.py \
+        -   job-requirements.txt \
+            /usr/src/app/
+
+        -   RUN pip install .

--- a/docs/src/faqs/setup_packaging.rst
+++ b/docs/src/faqs/setup_packaging.rst
@@ -1,0 +1,234 @@
+What do I need to know about using ``setup.py`` to package dependencies in Klio?
+================================================================================
+
+Using ``setup.py`` file to specify dependencies to install on workers
+was the original means by which a Python Beam job developer could
+customize the environment in which their job ran.
+You can read more about it
+`here <https://beam.apache.org/documentation/sdks/python-pipeline-dependencies/>`_.
+
+To configure a Klio job to run using ``setup.py`` packaging,
+the user needs to provide the required files (see below)
+and configure the job to use them
+by filling in the ``pipeline_options.setup_file`` field in their ``klio-job.yaml`` file:
+
+
+.. code-block:: yaml
+
+    job_name: my-job
+    pipeline_options:
+        setup_file: setup.py
+        # <-- snip -->
+
+Note that this method of setup is mutually exclusive with :ref:`using the FnAPI <migrate-from-fnapi>` for packaging.
+
+Required Files
+--------------
+
+.. _setup-py:
+
+``setup.py``
+^^^^^^^^^^^^
+
+A ``setup.py`` file is needed in the **root of your job's directory**. It partly substitutes the
+need for a worker image by installing any non-Python dependencies via a child process, and by
+explicitly including non-Python files needed for a job (i.e. a model, a JSON schema, etc).
+
+
+.. tip::
+
+    The ``setup.py`` must contain the required system-level dependencies, Python dependencies, and
+    required non-Python files (i.e. ML models, JSON schemas, etc) that your job requires to run.
+
+.. collapsible:: Minimal Example ``setup.py``
+
+    The following is an example with
+    a third party Python dependency available on PyPI
+    (but no non-public Python package dependencies),
+    a non-Python file (an ML model, ``my-model.h5``),
+    and no OS-level dependencies.
+
+    .. code-block:: python
+
+        import setuptools
+
+        setuptools.setup(
+            name="my-example-job",  # required
+            version="0.0.1",  # required
+            author="klio-devs",  # optional
+            author_email="hello@example.com",  # optional
+            description="My example job using setup.py",  # optional
+            install_requires=["tensorflow"],  # optional
+            data_files=[  # required
+                (".", ["klio-job.yaml", "my-model.h5"]),
+            ],
+            include_package_data=True,  # required
+            py_modules=["run", "transforms"],  # required
+        )
+
+
+
+.. collapsible:: Example ``setup.py`` with internal & OS-level dependencies
+
+    The following is a minimal example
+    that shows a method for including internal & OS-level dependencies, in
+    addition to .
+
+    .. code-block:: python
+
+        import subprocess
+        import setuptools
+
+        from distutils.command.build import build as _build
+
+
+        # NOTE: This class is required when using custom commands (i.e.
+        # installing OS-level deps and/or deps from internal PyPI)
+        class build(_build):
+            """A build command class that will be invoked during package install.
+
+            The package built using the current setup.py will be staged and
+            later installed in the worker using `pip install package'. This
+            class will be instantiated during install for this specific scenario
+            and will trigger running the custom commands specified.
+            """
+            sub_commands = _build.sub_commands + [('CustomCommands', None)]
+
+        # `APT_COMMANDS` and `REQUIREMENTS_COMMANDS` are custom commands that
+        # will run during setup that are required for this Klio job. Each
+        # command will spawn a child process.
+        APT_COMMANDS = [
+            ["apt-get", "update"],
+            # Debian-packaged dependencies (or otherwise OS-level requirements)
+            # `--assume-yes` to avoid interactive confirmation
+            ["apt-get", "install", "--assume-yes", "libsndfile1"],
+        ]
+        REQUIREMENTS_COMMANDS = [
+            [
+                "pip3",
+                "install",
+                "--default-timeout=120",
+                # --index-url will not work on Dataflow, but `--extra-index-url` will
+                "--extra-index-url",
+                # point to your internal PyPI
+                "pypi.internal.net",
+                "--requirement",
+                "job-requirements.txt",  # Must also be included in MANIFEST.in
+            ]
+        ]
+
+
+        # NOTE: This class is required when using custom commands (i.e.
+        # installing OS-level deps and/or deps from internal PyPI)
+        class CustomCommands(setuptools.Command):
+            """A setuptools Command class able to run arbitrary commands."""
+
+            def initialize_options(self):
+                # Method must be defined when implementing custom Commands
+                pass
+
+            def finalize_options(self):
+                # Method must be defined when implementing custom Commands
+                pass
+
+            def RunCustomCommand(self, command_list):
+                # NOTE: Output from the custom commands are missing from the
+                # logs. The output of custom commands (including failures) will
+                # be logged in the worker-startup log. (BEAM-3237)
+                print("Running command: %s" % " ".join(command_list))
+                p = subprocess.Popen(
+                    command_list,
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                )
+                stdout_data, _ = p.communicate()
+                print("Command output: %s" % stdout_data)
+                if p.returncode != 0:
+                    raise RuntimeError(
+                        "Command {} failed: exit code: {}".format(
+                            command_list, p.returncode
+                        )
+                    )
+
+            def run(self):
+                for command in APT_COMMANDS:
+                    self.RunCustomCommand(command)
+                for command in REQUIREMENTS_COMMANDS:
+                    self.RunCustomCommand(command)
+
+
+        # NOTE: `version` does not particularly mean anything here since we're
+        # not publishing to PyPI; it's just a required field
+        setuptools.setup(
+            name="my-example-job",  # required
+            version="0.0.1",  # required
+            author="klio-devs",  # optional
+            author_email="hello@example.com",  # optional
+            description="My example job using setup.py",  # optional
+            install_requires=[],  # optional if using the above REQUIREMENTS_COMMANDS
+            data_files=[  # required
+                # tuple(
+                #    str(dir where to install files, relative to Python modules),
+                #    list(str(non-Python filenames))
+                # )
+                (".", ["klio-job.yaml", "my-model.h5"]),
+            ],
+            include_package_data=True,  # required
+            py_modules=["run", "transforms"],  # required
+            # NOTE: required when using custom commands (i.e. installing OS-level
+            # deps and/or deps from internal PyPI)
+            cmdclass={  # optional
+                # Command class instantiated and run during pip install scenarios.
+                "build": build,
+                "CustomCommands": CustomCommands,
+            },
+        )
+
+.. _manifest-in:
+
+``MANIFEST.in``
+^^^^^^^^^^^^^^^
+
+A file called ``MANIFEST.in`` is needed in the **root of your job's directory** with the line
+``include job-requirements.txt``:
+
+.. code-block::
+
+    # cat MANIFEST.in
+    include job-requirements.txt
+
+
+.. collapsible:: Why is this needed?
+
+    The ``MANIFEST.in`` file must include any file required to *install* your job as a Python
+    package (but not needed to run your job; those files are declared under ``data_files``
+    in setup.py as referred :ref:`above <setup-py>`).
+
+    When Klio launches the job for Dataflow, Dataflow will locally create a `source distribution`_
+    of your job by running ``python setup.py sdist``. When running this, Python will tar together
+    the files declared in ``setup.py`` as well as any non-Python files defined in `MANIFEST.in`_
+    into a file called ``workflow.tar.gz`` (as named by Dataflow to then be uploaded).
+
+    Then, on the worker, Dataflow will run ``pip install workflow.tar.gz``. ``pip`` will actually
+    build a `wheel`_, installing packages defined in ``job-requirements.txt`` (and running any
+    other custom commands defined in ``setup.py``). After the installation of the package via
+    ``pip install workflow.tar.gz``, ``job-requirements.txt`` will effectively be gone and
+    inaccessible to the job's code. Building a wheel ignores ``MANIFEST.in``, but includes all the
+    files declared in ``setup.py``, the ones actually needed for running the Klio job.
+
+
+
+
+Limitations and Warnings
+------------------------
+
+* Currently, Klio in non-FnAPI mode does not yet support jobs with multiple configuration files. Support is planned.
+* ``pipeline_options.requirements_file`` configuration for `pipeline dependencies`_ **will not work** for Klio jobs. While klio will honor that configuration value for Dataflow to pick up, declaring requirements in ``setup.py`` is needed because a Klio job inherently has multiple Python files.
+* While Klio will still upload the worker image to `Google Container Registry`_ when running/deploying a job, Dataflow will *not* use the image. It is good practice to upload the worker image to ensure repeatable builds, but in the future, an option will be added to skip the upload.
+
+.. _source distribution: https://packaging.python.org/guides/distributing-packages-using-setuptools/#source-distributions
+.. _MANIFEST.in: https://packaging.python.org/guides/distributing-packages-using-setuptools/#manifest-in
+.. _wheel: https://packaging.python.org/guides/distributing-packages-using-setuptools/#wheels
+.. _pipeline dependencies: https://beam.apache.org/documentation/sdks/python-pipeline-dependencies/#pypi-dependencies
+.. _Google Container Registry: https://cloud.google.com/container-registry

--- a/docs/src/userguide/anatomy/files.rst
+++ b/docs/src/userguide/anatomy/files.rst
@@ -33,7 +33,7 @@ Python Files
 ``__init__.py`` helps the Python executable find the path where the other Python files are.
 
 ``setup.py`` file defines how the job should be packaged so the configured runner can appropriately install it.
-This is also where job-specific :violetemph:`system-level dependencies` should be declared.
+This is also where job-specific :violetemph:`system-level dependencies` should be declared. See :ref:`setup-py` for more information.
 
 Dependency Declaration
 ----------------------
@@ -53,25 +53,7 @@ Read more about a job's configuration :doc:`here <../config/index>`.
 Other Files
 -----------
 
-``MANIFEST.in`` declares files needed for job installation (i.e. ``job-requirements.txt``) but not needed at runtime.
-
-.. collapsible:: Why is this needed?
-
-    The ``MANIFEST.in`` file must include any file required to *install* your job as a Python
-    package (but not needed to run your job; those files are declared under ``data_files``
-    in ``setup.py`` as referred above).
-
-    When Klio launches the job for Dataflow, Dataflow will locally create a `source distribution`_
-    of your job by running ``python setup.py sdist``. When running this, Python will tar together
-    the files declared in ``setup.py`` as well as any non-Python files defined in `MANIFEST.in`_
-    into a file called ``workflow.tar.gz`` (as named by Dataflow to then be uploaded).
-
-    Then, on the worker, Dataflow will run ``pip install workflow.tar.gz``. ``pip`` will actually
-    build a `wheel`_, installing packages defined in ``job-requirements.txt`` (and running any
-    other custom commands defined in ``setup.py``). After the installation of the package via
-    ``pip install workflow.tar.gz``, ``job-requirements.txt`` will effectively be gone and
-    inaccessible to the job's code. Building a wheel ignores ``MANIFEST.in``, but includes all the
-    files declared in ``setup.py``, the ones actually needed for running the Klio job.
+``MANIFEST.in`` declares files needed for job installation (i.e. ``job-requirements.txt``) but not needed at runtime. See :ref:`manifest-in` for more information.
 
 ``README.md`` is initially populated with setup instructions on how to get a job running, but should be used however needed.
 


### PR DESCRIPTION
Since FnAPI is still experimental (and will be for quite some time), make documentation assume that the default is to use `setup.py` for packaging, rather than FnAPI.

<!--- How have you tested this?
n/a
-->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [x ] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ x] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ x] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
