### PR TITLE
[exec] Validate batch job packaging

### DIFF
--- a/exec/src/klio_exec/commands/run.py
+++ b/exec/src/klio_exec/commands/run.py
@@ -280,6 +280,13 @@ class KlioPipeline(object):
                 pipeline_opts.requirements_file
             )
 
+            if fnapi_enabled:
+                logging.warn(
+                    "Support for batch jobs using the 'beam_fn_api' "
+                    "experiment is still in development. "
+                    "Use with caution."
+                )
+
             if not any([fnapi_enabled, setup_file_exists, reqs_file_exists]):
                 logging.error(
                     "setup.py and/or requirements file either "

--- a/exec/src/klio_exec/commands/run.py
+++ b/exec/src/klio_exec/commands/run.py
@@ -272,6 +272,21 @@ class KlioPipeline(object):
             )
             raise SystemExit(1)
 
+        if not pipeline_opts.streaming:
+            setup_file_exists = has_setup_file and os.path.exists(
+                pipeline_opts.setup_file
+            )
+            reqs_file_exists = has_reqs_file and os.path.exists(
+                pipeline_opts.requirements_file
+            )
+
+            if not any([fnapi_enabled, setup_file_exists, reqs_file_exists]):
+                logging.error(
+                    "setup.py and/or requirements file either "
+                    "unspecified or not found."
+                )
+                raise SystemExit(1)
+
     def _setup_data_io_filters(self, in_pcol, label_prefix=None):
         # label prefixes are required for multiple inputs (to avoid label
         # name collisions in Beam)

--- a/exec/tests/unit/commands/test_run.py
+++ b/exec/tests/unit/commands/test_run.py
@@ -276,6 +276,22 @@ def test_verify_packaging_for_batch_raises(
         assert 1 == len(caplog.records)
 
 
+def test_verify_packaging_for_batch_warns(mocker, caplog):
+    mock_config = mocker.Mock()
+    mock_config.pipeline_options = mocker.Mock()
+    mock_config.pipeline_options.streaming = False
+    mock_config.pipeline_options.experiments = ["beam_fn_api"]
+    mock_config.pipeline_options.setup_file = None
+    mock_config.pipeline_options.requirements_file = None
+
+    kpipe = run.KlioPipeline("test-job", mock_config, mocker.Mock())
+
+    kpipe._verify_packaging()
+
+    assert 1 == len(caplog.records)
+    assert "WARNING" == caplog.records[0].levelname
+
+
 @pytest.mark.parametrize(
     "setup_file,reqs_file",
     (

--- a/exec/tests/unit/commands/test_run.py
+++ b/exec/tests/unit/commands/test_run.py
@@ -203,8 +203,9 @@ def test_get_image_tag(image, tag, expected_image):
     assert expected_image == actual_image
 
 
+@pytest.mark.parametrize("streaming", (True, False))
 @pytest.mark.parametrize(
-    "exp,setup_file,requirements_file",
+    "exp,setup_file, requirements_file",
     [
         ("beam_fn_api", None, None),
         (None, "setup.py", None),
@@ -212,19 +213,24 @@ def test_get_image_tag(image, tag, expected_image):
         (None, None, "requirements.txt"),
     ],
 )
-def test_verify_packaging(exp, setup_file, requirements_file, mocker):
+def test_verify_packaging(
+    exp, setup_file, requirements_file, streaming, mocker
+):
     mock_config = mocker.Mock()
     mock_config.pipeline_options = mocker.Mock()
     mock_config.pipeline_options.experiments = [exp]
     mock_config.pipeline_options.setup_file = setup_file
     mock_config.pipeline_options.requirements_file = requirements_file
+    mock_config.pipeline_options.streaming = streaming
+    mock_path_exists = mocker.patch.object(os.path, "exists")
+    mock_path_exists.return_value = True
 
     kpipe = run.KlioPipeline("test-job", mock_config, mocker.Mock())
 
     kpipe._verify_packaging()
 
 
-def test_verify_packaging_raises(mocker):
+def test_verify_packaging_with_both_packagaing_systems_raises(mocker):
     mock_config = mocker.Mock()
     mock_config.pipeline_options = mocker.Mock()
     mock_config.pipeline_options.experiments = ["beam_fn_api"]
@@ -234,6 +240,40 @@ def test_verify_packaging_raises(mocker):
 
     with pytest.raises(SystemExit):
         kpipe._verify_packaging()
+
+
+@pytest.mark.parametrize(
+    "has_setup_file, setup_file_exists", ((True, False), (False, False),)
+)
+@pytest.mark.parametrize(
+    "has_reqs_file, reqs_file_exists", ((True, False), (False, False),)
+)
+def test_verify_packaging_for_batch_raises(
+    mocker,
+    caplog,
+    has_setup_file,
+    setup_file_exists,
+    has_reqs_file,
+    reqs_file_exists,
+):
+    mock_config = mocker.Mock()
+    mock_config.pipeline_options = mocker.Mock()
+    mock_config.pipeline_options.streaming = False
+    mock_config.pipeline_options.experiments = []
+    if has_setup_file:
+        mock_config.pipeline_options.setup_file = "setup.py"
+    if has_reqs_file:
+        mock_config.pipeline_options.requirements_file = "requirements.txt"
+
+    mock_path_exists = mocker.patch.object(os.path, "exists")
+    mock_path_exists.side_effect = [setup_file_exists, reqs_file_exists]
+
+    kpipe = run.KlioPipeline("test-job", mock_config, mocker.Mock())
+
+    with pytest.raises(SystemExit):
+        kpipe._verify_packaging()
+
+        assert 1 == len(caplog.records)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Since the FnAPI is not yet stable for batch jobs, warn if it is being used.

 If it is not used and neither `requirements.txt` nor `setup.py` are being used to package dependencies, exit with an error.

<!--- How have you tested this?
* "I have included unit tests" 
* "I have run local integration tests"
-->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ x] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [x ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ x] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
