### PR TITLE
[lib] Support empty data config for helper filter transforms

### DIFF
--- a/docs/src/reference/lib/changelog.rst
+++ b/docs/src/reference/lib/changelog.rst
@@ -1,7 +1,16 @@
 Changelog
 =========
 
-0.2.2.post (2020-12-03)
+0.2.2 (UNRELEASED)
+------------------
+
+Fixed
+*****
+
+* Allow for support of empty ``job_config.data`` values for the built-in helper filter transforms.
+
+
+0.2.1.post2 (2020-12-03)
 ------------------------
 
 Fixed
@@ -10,7 +19,7 @@ Fixed
 * Requires klio-core>=0.2.1 now that dependent changes have been released in new core version
 
 
-0.2.1.post (2020-11-30)
+0.2.1.post1 (2020-11-30)
 ------------------------
 
 Fixed

--- a/lib/src/klio/transforms/_helpers.py
+++ b/lib/src/klio/transforms/_helpers.py
@@ -54,6 +54,18 @@ class TaggedStates(enum.Enum):
     DEFAULT = "tag_not_set"
 
 
+class KlioConfigRuntimeError(RuntimeError):
+    """Config error that should crash the job at startup."""
+
+    pass
+
+
+class KlioUnsupportedConfigError(KlioConfigRuntimeError):
+    """User-defined config is unsupported."""
+
+    pass
+
+
 # Only serializes to a KlioMessage; we deserialize within the process
 # method itself since we also have to tag the output (too difficult to
 # serialize output that's already tagged)
@@ -169,7 +181,7 @@ class _KlioInputDataMixin(object):
         if len(self._klio.config.job_config.data.inputs) > 1:
             # raise a runtime error so it actually crashes klio/beam rather than
             # just continue processing elements
-            raise RuntimeError(
+            raise KlioUnsupportedConfigError(
                 "Multiple inputs configured in "
                 "`klio-job.yaml::job_config.data.inputs` are not supported "
                 "for data existence checks."
@@ -180,7 +192,7 @@ class _KlioInputDataMixin(object):
         if len(self._klio.config.job_config.data.inputs) == 0:
             # raise a runtime error so it actually crashes klio/beam rather than
             # just continue processing elements
-            raise RuntimeError(
+            raise KlioConfigRuntimeError(
                 "Input data existence checks require input data to be "
                 "configured in `klio-job.yaml::job_config.data.inputs`."
             )
@@ -205,7 +217,7 @@ class _KlioOutputDataMixin(object):
         if len(self._klio.config.job_config.data.outputs) > 1:
             # raise a runtime error so it actually crashes klio/beam rather than
             # just continue processing elements
-            raise RuntimeError(
+            raise KlioUnsupportedConfigError(
                 "Multiple outputs configured in "
                 "`klio-job.yaml::job_config.data.outputs` are not supported "
                 "for data existence checks."
@@ -217,7 +229,7 @@ class _KlioOutputDataMixin(object):
         if len(self._klio.config.job_config.data.outputs) == 0:
             # raise a runtime error so it actually crashes klio/beam rather than
             # just continue processing elements
-            raise RuntimeError(
+            raise KlioConfigRuntimeError(
                 "Output data existence checks require output data to be "
                 "configured in `klio-job.yaml::job_config.data.outputs`."
             )


### PR DESCRIPTION
<!--- Describe your changes 

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

We allow users to not have to define inputs and/or outputs under `job_config.data` in their klio-job.yaml. But these helper filter transforms (`KlioFilterForce` and `KlioFilterPing`) implicitly expected data config to be there, when that shouldn’t be the case. This is a small (maybe not the most ideal) work around for that (tbh not sure what the most ideal way would be to approach this, but this was quick ¯\\_(ツ)_/¯ ).

<!--- How have you tested this?
Some valid responses are:

* "I have included unit tests" 
* "I have included integration tests"
* "I successfully ran my jobs with this code"

-->

I successfully ran jobs that have otherwise failed with issue.

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [x] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
