### PR TITLE
[docs] Add reference docs for klioexec 

### DIFF
--- a/docs/src/reference/cli/index.rst
+++ b/docs/src/reference/cli/index.rst
@@ -58,8 +58,8 @@ Klio CLI
 
 
 .. |image| replace:: ``image``
-.. _image: ./image.html
+.. _image: ./api/cli/image.html
 .. |job| replace:: ``job``
-.. _job: ./job.html
+.. _job: ./api/cli/job.html
 .. |message| replace:: ``message``
-.. _message: ./message.html
+.. _message: ./api/cli/message.html

--- a/docs/src/reference/executor/api.rst
+++ b/docs/src/reference/executor/api.rst
@@ -1,6 +1,0 @@
-API
-===
-
-.. todo::
-
-    Once the klio packages are released on PyPI, use ``autodocs`` to generate this API documentation for the ``klio-exec`` package.

--- a/docs/src/reference/executor/index.rst
+++ b/docs/src/reference/executor/index.rst
@@ -10,7 +10,12 @@ Klio Executor
 
 
 .. toctree::
-   :maxdepth: 1
+    :maxdepth: 1
+    :hidden:
 
-   api
-   changelog
+    CLI <self>
+    changelog
+
+.. click:: klio_exec.cli:main
+    :prog: klioexec
+    :nested: full


### PR DESCRIPTION
Adds reference documentation for the klioexec CLI.

<!--- How have you tested this?
Some valid responses are:
* I built docs locally and read them.

-->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ x] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ x] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ x] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
