### PR TITLE
[exec] Remove misleading references to requirements.txt for batch packaging

### DIFF
--- a/exec/src/klio_exec/commands/run.py
+++ b/exec/src/klio_exec/commands/run.py
@@ -276,10 +276,6 @@ class KlioPipeline(object):
             setup_file_exists = has_setup_file and os.path.exists(
                 pipeline_opts.setup_file
             )
-            reqs_file_exists = has_reqs_file and os.path.exists(
-                pipeline_opts.requirements_file
-            )
-
             if fnapi_enabled:
                 logging.warn(
                     "Support for batch jobs using the 'beam_fn_api' "
@@ -287,12 +283,18 @@ class KlioPipeline(object):
                     "Use with caution."
                 )
 
-            if not any([fnapi_enabled, setup_file_exists, reqs_file_exists]):
-                logging.error(
-                    "setup.py and/or requirements file either "
-                    "unspecified or not found."
-                )
-                raise SystemExit(1)
+            if not any([fnapi_enabled, setup_file_exists]):
+                if has_reqs_file:
+                    logging.warn(
+                        "Klio jobs are multi-module. "
+                        "Thus, a setup.py file is required "
+                        "in addition to a requirements.txt file"
+                    )
+                else:
+                    logging.error(
+                        "setup.py file either unspecified or not found."
+                    )
+                    raise SystemExit(1)
 
     def _setup_data_io_filters(self, in_pcol, label_prefix=None):
         # label prefixes are required for multiple inputs (to avoid label


### PR DESCRIPTION
Since Klio jobs are inherently multi-module, a `requirements.txt` file is not sufficient to package a klio job. This PR removes the misleading check for the existence of the `requirements.txt` file.

<!--- How have you tested this?
Some valid responses are:

* "I have included unit tests" 
-->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ x] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ x] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ x] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
