### PR TITLE
[core] switch `klio_core.utils.get_publisher` to using google-cloud-pubsub 2.0.0

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -156,7 +156,7 @@ INSTALL_REQUIRES = [
     "google-api-python-client",
     "google-api-core>=1.21.0",  # TODO: try and remove
     "google-cloud-core>=1.4.1",
-    "google-cloud-pubsub",  # TODO: try and remove
+    "google-cloud-pubsub>=2.0.0",  # TODO: try and remove
     "protobuf>=3.12.0",
     "pyyaml",
     "six",

--- a/core/src/klio_core/utils.py
+++ b/core/src/klio_core/utils.py
@@ -94,7 +94,7 @@ def get_or_initialize_global(name, initializer):
 def _get_publisher(topic):
     publisher = pubsub.PublisherClient()
     try:
-        publisher.create_topic(topic)
+        publisher.create_topic(request={"name": topic})
     except gapi_exceptions.AlreadyExists:
         pass
 

--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -85,7 +85,9 @@ def test_private_get_publisher(mock_publisher):
     ret_publisher = utils._get_publisher("a-topic")
 
     mock_publisher.assert_called_once_with()
-    mock_publisher.return_value.create_topic.assert_called_once_with("a-topic")
+    mock_publisher.return_value.create_topic.assert_called_once_with(
+        request={"name": "a-topic"}
+    )
 
     assert mock_publisher.return_value == ret_publisher
 
@@ -97,7 +99,7 @@ def test_private_get_publisher_topic_exists(mock_publisher):
     ret_publisher = utils._get_publisher("a-topic")
 
     mock_publisher.assert_called_once_with()
-    client.create_topic.assert_called_once_with("a-topic")
+    client.create_topic.assert_called_once_with(request={"name": "a-topic"})
 
     assert client == ret_publisher
 
@@ -110,7 +112,7 @@ def test_private_get_publisher_raises(mock_publisher):
         utils._get_publisher("a-topic")
 
     mock_publisher.assert_called_once_with()
-    client.create_topic.assert_called_once_with("a-topic")
+    client.create_topic.assert_called_once_with(request={"name": "a-topic"})
 
 
 @pytest.mark.parametrize("in_globals", (True, False))


### PR DESCRIPTION
`google-cloud-pubsub` has breaking changes in its interfaces. If users use the function `kli_core.utils.get_publisher`,  they will get an `Invalid constructor input` error.

<!--- How have you tested this?
Some valid responses are:
* "I have included unit tests" 
-->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [x] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [x] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [x] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
