### PR TITLE
[core] fix preprocessing of config io fields

### DIFF
--- a/cli/src/klio_cli/cli.py
+++ b/cli/src/klio_cli/cli.py
@@ -403,7 +403,7 @@ def audit_job(klio_config, config_meta, force_build, image_tag, list_steps):
 # `klio job config` subcommands
 #####
 def _job_config(job_dir, config_file, verb, *args, **kwargs):
-    _, config_path = cli_utils.get_config_job_dir(job_dir, config_file)
+    _, config_path = core_utils.get_config_job_dir(job_dir, config_file)
 
     effective_job_config = job_commands.configuration.EffectiveJobConfig(
         config_path

--- a/cli/src/klio_cli/commands/base.py
+++ b/cli/src/klio_cli/commands/base.py
@@ -182,7 +182,7 @@ class BaseDockerizedPipeline(object):
                 prefix="/tmp/", mode="w", delete=False
             )
             yaml.dump(
-                self.klio_config._raw,
+                self.klio_config.as_dict(),
                 stream=self.materialized_config_file,
                 Dumper=configuration.IndentListDumper,
                 default_flow_style=False,

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -664,7 +664,9 @@ def test_test_job(
         mock_get_git_sha.assert_not_called()
 
     mock_get_config.assert_called_once_with(conf_override or config_file)
-    mock_klio_config.assert_called_once_with(config_data)
+    mock_klio_config.assert_called_once_with(
+        config_data, raw_overrides=(), raw_templates=()
+    )
     exp_docker_runtime_config = cli.DockerRuntimeConfig(
         image_tag=exp_image_tag,
         force_build=False,

--- a/core/src/klio_core/_testing.py
+++ b/core/src/klio_core/_testing.py
@@ -96,7 +96,9 @@ class MockKlioConfig(object):
         self.mock_get_config.assert_called_once_with(
             self.effective_config_path
         )
-        self.mock_klio_config.assert_called_once_with(self.config_data)
+        self.mock_klio_config.assert_called_once_with(
+            self.config_data, raw_overrides=(), raw_templates=()
+        )
         self.mock_warn_if_py2_job.assert_called_once_with(
             self.effective_job_dir
         )

--- a/core/src/klio_core/config/_preprocessing.py
+++ b/core/src/klio_core/config/_preprocessing.py
@@ -82,6 +82,10 @@ class KlioConfigPreprocessor(object):
         for conf in io_subsection_list:
             if "name" in conf:
                 name = conf["name"]
+                # TODO: right now "name" isn't supported in IOConfig (conflicts
+                # with existing "name" attribute), once that's fixed we
+                # shouldn't drop name here
+                conf.pop("name")
             else:
                 type_name = conf.get("type", "unknown")
                 type_id = type_counters[type_name]
@@ -97,7 +101,7 @@ class KlioConfigPreprocessor(object):
         clone = config_dict.copy()
         for io_type in ["events", "data"]:
             for io_direction in ["inputs", "outputs"]:
-                path = "{}.{}".format(io_type, io_direction)
+                path = "job_config.{}.{}".format(io_type, io_direction)
 
                 glom_assign = glom.Assign(
                     path, glom.Spec((path, cls._transform_io_list))

--- a/core/src/klio_core/utils.py
+++ b/core/src/klio_core/utils.py
@@ -222,17 +222,15 @@ def with_klio_config(func):
 
         raw_config_data = get_config_by_path(config_path)
 
-        processed_config_data = config.KlioConfigPreprocessor.process(
-            raw_config_data=raw_config_data,
-            raw_template_list=raw_templates,
-            raw_override_list=raw_overrides,
+        conf = config.KlioConfig(
+            raw_config_data,
+            raw_templates=raw_templates,
+            raw_overrides=raw_overrides,
         )
 
         meta = KlioConfigMeta(
             job_dir=job_dir, config_file=config_file, config_path=config_path,
         )
-
-        conf = config.KlioConfig(processed_config_data)
 
         kwargs["klio_config"] = conf
         kwargs["config_meta"] = meta

--- a/core/tests/config/test_config.py
+++ b/core/tests/config/test_config.py
@@ -24,25 +24,30 @@ def job_config_dict():
     return {
         "metrics": {"logger": {}},
         "events": {
-            "inputs": [
-                {
+            "inputs": {
+                "pubsub0": {
                     "type": "pubsub",
                     "topic": "test-parent-job-out",
                     "subscription": "test-parent-job-out-sub",
                 },
-            ],
-            "outputs": [{"type": "pubsub", "topic": "test-job-out"}],
+            },
+            "outputs": {
+                "pubsub0": {"type": "pubsub", "topic": "test-job-out"}
+            },
         },
         "data": {
-            "inputs": [
-                {
+            "inputs": {
+                "gcs0": {
                     "type": "GCS",
                     "location": "gs://sigint-output/test-parent-job-out",
                 }
-            ],
-            "outputs": [
-                {"type": "GCS", "location": "gs://sigint-output/test-job-out"}
-            ],
+            },
+            "outputs": {
+                "gcs0": {
+                    "type": "GCS",
+                    "location": "gs://sigint-output/test-job-out",
+                }
+            },
         },
         "more": "config",
         "that": {"the": "user"},
@@ -382,7 +387,7 @@ def test_klio_pipeline_config(
 
 def test_klio_config(config_dict, final_config_dict):
 
-    config_obj = config.KlioConfig(config_dict)
+    config_obj = config.KlioConfig(config_dict, config_skip_preprocessing=True)
 
     assert "test-job" == config_obj.job_name
     assert isinstance(config_obj.job_config, config.KlioJobConfig)
@@ -395,7 +400,9 @@ def test_klio_config(config_dict, final_config_dict):
 
 def test_no_gcp_klio_config(no_gcp_config_dict):
 
-    config_obj = config.KlioConfig(no_gcp_config_dict)
+    config_obj = config.KlioConfig(
+        no_gcp_config_dict, config_skip_preprocessing=True
+    )
 
     assert "test-job" == config_obj.job_name
     assert isinstance(config_obj.job_config, config.KlioJobConfig)

--- a/core/tests/config/test_preprocessing.py
+++ b/core/tests/config/test_preprocessing.py
@@ -223,6 +223,56 @@ def test_apply_templates(
         assert expected == json.loads(new_dict)
 
 
+def test_transform_io(kcp):
+    config = {
+        "job_config": {
+            "events": {
+                "inputs": [
+                    {"type": "bq", "key": "value"},
+                    {"type": "bq", "key": "value2"},
+                    {"type": "gcs", "gcskey": "gcsvalue"},
+                ],
+                "outputs": [
+                    {"type": "bq", "key": "value", "name": "mybq"},
+                    {"type": "bq", "key": "value2"},
+                ],
+            },
+            "data": {
+                "inputs": [],
+                "outputs": [
+                    {"type": "bq", "key": "value", "name": "mybq"},
+                    {"type": "bq", "key": "value2"},
+                ],
+            },
+        }
+    }
+    expected = {
+        "job_config": {
+            "events": {
+                "inputs": {
+                    "bq0": {"type": "bq", "key": "value"},
+                    "bq1": {"type": "bq", "key": "value2"},
+                    "gcs0": {"type": "gcs", "gcskey": "gcsvalue"},
+                },
+                "outputs": {
+                    "mybq": {"type": "bq", "key": "value"},
+                    "bq0": {"type": "bq", "key": "value2"},
+                },
+            },
+            "data": {
+                "inputs": {},
+                "outputs": {
+                    "mybq": {"type": "bq", "key": "value"},
+                    "bq0": {"type": "bq", "key": "value2"},
+                },
+            },
+        }
+    }
+    actual = kcp._transform_io_sections(config)
+
+    assert actual == expected
+
+
 def test_apply_plugin_preprocessing(mocker, kcp):
 
     config = {

--- a/docs/src/reference/cli/changelog.rst
+++ b/docs/src/reference/cli/changelog.rst
@@ -1,6 +1,13 @@
 CLI Changelog
 =============
 
+1.0.5 (UNRELEASED)
+------------------
+
+Fixed
+*****
+* Fixed a runtime bug in ``klio job config`` commands
+
 1.0.4 (2021-01-04)
 ------------------
 

--- a/docs/src/reference/core/changelog.rst
+++ b/docs/src/reference/core/changelog.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+0.2.2 (UNRELEASED)
+------------------
+
+Fixed
+*****
+
+* fix config bug that skipped preprocessing (overrides, templates) of dict parsed from YAML
+
 0.2.1 (2020-12-03)
 ------------------
 


### PR DESCRIPTION
Looks like we weren't actually applying the transform on raw config that converted the lists of I/O to nested dicts.  Luckily this had no real effect except on correctly handling overrides.

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [x] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [x] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [x] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
