### PR TITLE
[lib] Bugfix: klio serialization in helpers & for non-klio messages.

### DIFF
--- a/docs/src/reference/lib/changelog.rst
+++ b/docs/src/reference/lib/changelog.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+0.2.3 (2021-01-04)
+------------------
+
+Fixed
+*****
+
+* Fixed non-Klio -> Klio message parsing.
+* Fixed calling of ``to_klio_message`` in helper transforms.
+
 0.2.2 (2020-12-11)
 ------------------
 

--- a/lib/setup.cfg
+++ b/lib/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.2
+current_version = 0.2.3
 commit = True
 tag = True
 tag_name = lib-{new_version}

--- a/lib/src/klio/__init__.py
+++ b/lib/src/klio/__init__.py
@@ -14,7 +14,7 @@
 #
 
 __author__ = "The klio developers"
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 __email__ = "opensource+klio@spotify.com"
 __description__ = "Conventions for Python + Apache Beam "
 __uri__ = "https://github.com/spotify/klio"

--- a/lib/src/klio/message/serializer.py
+++ b/lib/src/klio/message/serializer.py
@@ -92,6 +92,10 @@ def to_klio_message(incoming_message, kconfig=None, logger=None):
             # We are assuming that we have been given "raw" data that is not in
             # the form of a serialized KlioMessage.
             parsed_message.data.element = incoming_message
+            # default to set recipients to anyone - can't know who the
+            # appropriate recipient is when it's not a real klio msg
+            parsed_message.metadata.intended_recipients.anyone.SetInParent()
+            parsed_message.version = klio_pb2.Version.V2
         else:
             logger.error(
                 "Can not parse incoming message. To support non-Klio "

--- a/lib/tests/unit/message/test_serializer.py
+++ b/lib/tests/unit/message/test_serializer.py
@@ -107,6 +107,7 @@ def test_to_klio_message_allow_non_kmsg(klio_config, logger, monkeypatch):
     expected = klio_pb2.KlioMessage()
     expected.data.element = incoming
     expected.version = klio_pb2.Version.V2
+    expected.metadata.intended_recipients.anyone.SetInParent()
 
     actual_message = serializer.to_klio_message(incoming, klio_config, logger)
 


### PR DESCRIPTION
<!--- Describe your changes 

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

When working on my Klio pet, I noticed two things wrong with Klio serialization:

1. When working with non-Klio messages, Klio will load the whole non-Klio message into `kmsg.data.element` (as expected). But it did not set the message version or the recipients, both of which are expected in other parts of the code. The first commit addresses that.
2. Some of the helper transforms take in a raw pubsub message and need to serialize it into a Klio message. They were not providing all the required function arguments when serializing to Klio message, and the second commit addresses that.

<!--- How have you tested this?
Some valid responses are:

* "I have included unit tests" 
* "I have included integration tests"
* "I successfully ran my jobs with this code"

-->

* Updated unit tests
* Successfully ran my Klio pet job with these changes

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [x] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [x] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [x] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
