### PR TITLE
[lib] Fix which changelog to read from for long desc

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -180,7 +180,7 @@ setup(
     name=NAME,
     version=find_meta("version"),
     description=find_meta("description"),
-    long_description=get_long_description("executor"),
+    long_description=get_long_description("lib"),
     long_description_content_type="text/x-rst",
     url=find_meta("uri"),
     project_urls=PROJECT_URLS,


### PR DESCRIPTION
<!--- Describe your changes 

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

I noticed when releasing `klio==0.2.3` to PyPI, that it was pulling in `klio-exec`'s long description information. When releasing `klio==0.2.3`, I made this change locally so it will look correct on PyPI. I checked the other packages and all are fine - I'm guessing it was copy-pasta.

<!--- How have you tested this?
Some valid responses are:

* "I have included unit tests" 
* "I have included integration tests"
* "I successfully ran my jobs with this code"

-->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ ] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
