### PR TITLE
[cli] Release 1.0.4

### DIFF
--- a/cli/setup.cfg
+++ b/cli/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.3
+current_version = 1.0.4
 tag_name = cli-{new_version}
 commit = True
 tag = True

--- a/cli/src/klio_cli/__init__.py
+++ b/cli/src/klio_cli/__init__.py
@@ -14,7 +14,7 @@
 #
 
 __author__ = "The klio developers"
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 __email__ = "opensource+klio@spotify.com"
 __description__ = "Main entrypoint for Klio jobs"
 __uri__ = "https://github.com/spotify/klio"

--- a/docs/src/reference/cli/changelog.rst
+++ b/docs/src/reference/cli/changelog.rst
@@ -1,6 +1,14 @@
 CLI Changelog
 =============
 
+1.0.4 (2021-01-04)
+------------------
+
+Fixed
+*****
+Fixes "klioexec: error: unrecognized arguments: --config-file" error in
+test command.
+
 1.0.3 (2020-12-16)
 ------------------
 


### PR DESCRIPTION
This release fixes a bug in the `klio job test` command that causes the user to receive the error `klioexec: error: unrecognized arguments: --config-file` (#140)

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [x] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [x] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [x] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
