### PR TITLE
[core] fixing config as_dict not including custom keys on dataflow

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -170,6 +170,7 @@ EXTRAS_REQUIRE = {
         "pytest>=4.3.0",  # 4.3.0 dropped last use of `convert`
         "pytest-cov",
         "pytest-mock",
+        "dill",
     ],
 }
 EXTRAS_REQUIRE["dev"] = (

--- a/core/src/klio_core/config/core.py
+++ b/core/src/klio_core/config/core.py
@@ -143,7 +143,6 @@ class KlioJobConfig(object):
     """
 
     ATTRIBS_TO_SKIP = ["version", "job_name"]
-    USER_ATTRIBS = []
 
     # required attributes
     job_name = utils.field(type=str, repr=True)
@@ -157,6 +156,7 @@ class KlioJobConfig(object):
     def __config_post_init__(self, config_dict):
         self._raw = config_dict
         self._scanned_io_subclasses = None
+        self.USER_ATTRIBS = []
 
         self._parse_io(config_dict)
 
@@ -322,7 +322,6 @@ class KlioPipelineConfig(object):
     """
 
     ATTRIBS_TO_SKIP = ["version"]
-    USER_ATTRIBS = []
 
     job_name = utils.field(repr=True, type=str)
     version = utils.field(type=int)
@@ -399,6 +398,7 @@ class KlioPipelineConfig(object):
             self.labels.append(self.label)
 
         self.max_num_workers = max(2, self.num_workers)
+        self.USER_ATTRIBS = []
 
         if self.worker_disk_type is not None:
             self.worker_disk_type = WORKER_DISK_TYPE_URL.format(


### PR DESCRIPTION
This fixes a bug where calling `klio_config.as_dict()` in a transform would not include user-defined config keys only when executed in dataflow.

Basically `USER_ATTRIBS` was defined as a class-level attribute, which means it would not get pickled with other class attributes when sent to dataflow.  This explains that while the keys didn't appear in the generated dict, they did exist on dataflow through direct access.

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ ] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
