### PR TITLE
[integration] Fail if `klio job test` or `klio job run` fails during integration tests

### DIFF
--- a/integration/batch-modular-default/tests/test_transforms.py
+++ b/integration/batch-modular-default/tests/test_transforms.py
@@ -41,6 +41,14 @@ def klio_msg():
 @pytest.fixture
 def expected_log_messages(klio_msg):
     return [
+        (
+            "KlioThreadLimiter(name=LogKlioMessage.process) Blocked – "
+            "waiting on semaphore for an available thread (available threads:"
+        ),
+        (
+            "KlioThreadLimiter(name=LogKlioMessage.process) Released "
+            "semaphore (available threads:"
+        ),
         "Received element {}".format(klio_msg.data.element),
         "Received payload {}".format(klio_msg.data.payload),
     ]
@@ -52,6 +60,8 @@ def test_process(klio_msg, expected_log_messages, caplog):
 
     assert klio_msg.SerializeToString() == list(output)[0]
 
+    assert len(caplog.records) == len(expected_log_messages)
+
     for index, record in enumerate(caplog.records):
         assert "INFO" == record.levelname
-        assert expected_log_messages[index] == record.message
+        assert expected_log_messages[index] in record.message

--- a/integration/read-bq-write-bq/tests/test_transforms.py
+++ b/integration/read-bq-write-bq/tests/test_transforms.py
@@ -41,6 +41,14 @@ def klio_msg():
 @pytest.fixture
 def expected_log_messages(klio_msg):
     return [
+        (
+            "KlioThreadLimiter(name=LogKlioMessage.process) Blocked – "
+            "waiting on semaphore for an available thread (available threads:"
+        ),
+        (
+            "KlioThreadLimiter(name=LogKlioMessage.process) Released "
+            "semaphore (available threads:"
+        ),
         "Hello, Klio!",
         "Received element {}".format(klio_msg.data.element),
         "Received payload {}".format(klio_msg.data.payload),
@@ -62,7 +70,9 @@ def test_process(klio_msg, expected_log_messages, caplog):
 
     assert expected_kmsg.SerializeToString() == list(output)[0]
 
+    assert len(caplog.records) == len(expected_log_messages)
+
     for index, record in enumerate(caplog.records):
         assert "INFO" == record.levelname
-        assert expected_log_messages[index] == record.message
+        assert expected_log_messages[index] in record.message
 

--- a/integration/read-file-write-file/tests/test_transforms.py
+++ b/integration/read-file-write-file/tests/test_transforms.py
@@ -42,6 +42,14 @@ def klio_msg():
 @pytest.fixture
 def expected_log_messages(klio_msg):
     return [
+        (
+            "KlioThreadLimiter(name=LogKlioMessage.process) Blocked – waiting "
+            "on semaphore for an available thread (available threads:"
+        ),
+        (
+            "KlioThreadLimiter(name=LogKlioMessage.process) Released "
+            "semaphore (available threads:"
+        ),
         "Hello, Klio!",
         "Received element {}".format(klio_msg.data.element),
         "Received payload {}".format(klio_msg.data.payload),
@@ -53,7 +61,9 @@ def test_process(klio_msg, expected_log_messages, caplog):
     output = helloklio_fn.process(klio_msg.SerializeToString())
     assert klio_msg.SerializeToString() == list(output)[0]
 
+    assert len(caplog.records) == len(expected_log_messages)
+
     for index, record in enumerate(caplog.records):
         assert "INFO" == record.levelname
-        assert expected_log_messages[index] == record.message
+        assert expected_log_messages[index] in record.message
 

--- a/integration/read-file/tests/test_transforms.py
+++ b/integration/read-file/tests/test_transforms.py
@@ -42,6 +42,14 @@ def klio_msg():
 @pytest.fixture
 def expected_log_messages(klio_msg):
     return [
+        (
+            "KlioThreadLimiter(name=LogKlioMessage.process) Blocked – "
+            "waiting on semaphore for an available thread (available threads:"
+        ),
+        (
+            "KlioThreadLimiter(name=LogKlioMessage.process) Released "
+            "semaphore (available threads:"
+        ),
         "Hello, Klio!",
         "Received element {}".format(klio_msg.data.element),
         "Received payload {}".format(klio_msg.data.payload),
@@ -53,7 +61,9 @@ def test_process(klio_msg, expected_log_messages, caplog):
     output = helloklio_fn.process(klio_msg.SerializeToString())
     assert klio_msg.SerializeToString() == list(output)[0]
 
+    assert len(caplog.records) == len(expected_log_messages)
+
     for index, record in enumerate(caplog.records):
         assert "INFO" == record.levelname
-        assert expected_log_messages[index] == record.message
+        assert expected_log_messages[index] in record.message
 


### PR DESCRIPTION
<!--- Describe your changes 

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

Before, integration tests would succeed even if `klio job test` or `klio job run` failed. The success of the testing would just depend on how the very last command in `tox_commands.sh` did.

I introduced a few minor failures when merging in #135 (expected logs didn't match actual logs), so I fixed those as well.

<!--- How have you tested this?
Some valid responses are:

* "I have included unit tests" 
* "I have included integration tests"
* "I successfully ran my jobs with this code"

-->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ ] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
