### PR TITLE
[exec,lib] partial revert of using main_session for KlioConfig

### DIFF
--- a/exec/tests/unit/test_cli.py
+++ b/exec/tests/unit/test_cli.py
@@ -134,6 +134,13 @@ def patch_run_basic_pipeline(mocker, monkeypatch):
     return mock
 
 
+@pytest.fixture
+def mock_compare_runtime_to_buildtime_config(mocker, monkeypatch):
+    mock = mocker.Mock()
+    monkeypatch.setattr(cli, "_compare_runtime_to_buildtime_config", mock)
+    return mock
+
+
 def test_get_config(tmpdir, config):
     tmp_config = tmpdir.mkdir("klio-exec-testing").join("klio-job.yaml")
     tmp_config.write(yaml.dump(config))
@@ -168,6 +175,42 @@ def test_get_config_raises(tmpdir, caplog):
     assert 1 == len(caplog.records)
 
 
+@pytest.mark.parametrize(
+    "addl_runtime_data,buildtime_exists,exp_retval",
+    (
+        (False, True, True),
+        (True, True, False),
+        (False, False, True),
+        (True, False, False),  # not possible but CYA
+    ),
+)
+def test_compare_runtime_to_buildtime_config(
+    mocker, monkeypatch, addl_runtime_data, buildtime_exists, exp_retval
+):
+    monkeypatch.setattr(os.path, "exists", lambda x: buildtime_exists)
+
+    buildtime_data = {"job_name": "foo", "job_config": {}}
+    runtime_data = buildtime_data.copy()
+    if addl_runtime_data:
+        runtime_data["job_config"] = runtime_data["job_config"].copy()
+        runtime_data["job_config"]["foo"] = "bar"
+
+    # multiple `open` mocks: https://stackoverflow.com/a/26830397/1579977
+    open_name = "klio_exec.cli.open"
+    buildtime_data_str = yaml.dump(buildtime_data).encode("utf-8")
+
+    runtime_conf = kconfig.KlioConfig(runtime_data)
+
+    mock_open_buildtime = mocker.mock_open(read_data=buildtime_data_str)
+    mock_open = mocker.patch(open_name, mock_open_buildtime)
+
+    side_effect = (mock_open_buildtime.return_value,)
+    mock_open.side_effect = side_effect
+
+    act_retval = cli._compare_runtime_to_buildtime_config(runtime_conf)
+    assert exp_retval == act_retval
+
+
 @pytest.mark.parametrize("blocking", (True, False, None))
 @pytest.mark.parametrize(
     "image_tag,direct_runner,update",
@@ -188,7 +231,9 @@ def test_run_pipeline(
     cli_runner,
     mock_klio_config,
     patch_run_basic_pipeline,
+    mock_compare_runtime_to_buildtime_config,
 ):
+    mock_compare_runtime_to_buildtime_config.return_value = True
     runtime_conf = cli.RuntimeConfig(
         image_tag=None, direct_runner=False, update=None, blocking=None
     )
@@ -219,21 +264,33 @@ def test_run_pipeline(
     mock_klio_config.assert_calls()
 
     patch_run_basic_pipeline.assert_called_once_with()
+    mock_compare_runtime_to_buildtime_config.assert_called_once_with(
+        mock_klio_config.klio_config
+    )
 
 
 @pytest.mark.parametrize(
-    "config_file_override", (None, "klio-job2.yaml"),
+    "config_file_override,compare_conf_retval",
+    (
+        (None, True),
+        (None, False),
+        ("klio-job2.yaml", True),
+        ("klio-job2.yaml", False),
+    ),
 )
 def test_run_pipeline_conf_override(
     config_file_override,
+    compare_conf_retval,
     cli_runner,
     config,
     mock_klio_config,
     patch_run_basic_pipeline,
+    mock_compare_runtime_to_buildtime_config,
     caplog,
     tmpdir,
     monkeypatch,
 ):
+    mock_compare_runtime_to_buildtime_config.return_value = compare_conf_retval
 
     cli_inputs = []
 
@@ -260,7 +317,15 @@ def test_run_pipeline_conf_override(
 
     patch_run_basic_pipeline.assert_called_once_with()
 
-    assert 0 == len(caplog.records)
+    mock_compare_runtime_to_buildtime_config.assert_called_once_with(
+        mock_klio_config.klio_config
+    )
+
+    if compare_conf_retval is False:
+        assert 1 == len(caplog.records)
+        assert "WARNING" == caplog.records[0].levelname
+    else:
+        assert 0 == len(caplog.records)
 
 
 @pytest.mark.parametrize("config_file_override", (None, "klio-job2.yaml"))

--- a/lib/tests/unit/transforms/test_core.py
+++ b/lib/tests/unit/transforms/test_core.py
@@ -13,7 +13,12 @@
 # limitations under the License.
 #
 
+import os
+
 import pytest
+import yaml
+
+from klio_core import config
 
 from klio.metrics import logger as logger_metrics
 from klio.metrics import stackdriver as sd_metrics
@@ -92,6 +97,43 @@ def test_klio_metrics(
         assert isinstance(actual_relay, exp_clients)
         if isinstance(actual_relay, logger_metrics.MetricsLoggerClient):
             assert exp_logger_enabled is not actual_relay.disabled
+
+
+@pytest.mark.parametrize("exists", (True, False))
+def test_load_config_from_file(exists, config_dict, mocker, monkeypatch):
+    monkeypatch.setattr(os.path, "exists", lambda x: exists)
+
+    klio_yaml_file = "/usr/src/config/.effective-klio-job.yaml"
+    if not exists:
+        klio_yaml_file = "/usr/lib/python/site-packages/klio/klio-job.yaml"
+        mock_iglob = mocker.Mock()
+        mock_iglob.return_value = iter([klio_yaml_file])
+        monkeypatch.setattr(core_transforms.glob, "iglob", mock_iglob)
+
+    open_name = "klio.transforms.core.open"
+    config_str = yaml.dump(config_dict)
+    m_open = mocker.mock_open(read_data=config_str)
+    m = mocker.patch(open_name, m_open)
+
+    klio_config = core_transforms.RunConfig._load_config_from_file()
+
+    m.assert_called_once_with(klio_yaml_file, "r")
+    assert isinstance(klio_config, config.KlioConfig)
+    if not exists:
+        mock_iglob.assert_called_once_with(
+            "/usr/**/klio-job.yaml", recursive=True
+        )
+
+
+def test_load_config_from_file_raises(config_dict, mocker, monkeypatch):
+    monkeypatch.setattr(os.path, "exists", lambda x: False)
+
+    mock_iglob = mocker.Mock()
+    mock_iglob.return_value = iter([])
+    monkeypatch.setattr(core_transforms.glob, "iglob", mock_iglob)
+
+    with pytest.raises(IOError):
+        core_transforms.RunConfig._load_config_from_file()
 
 
 @pytest.mark.parametrize("thread_local_ret", (True, False))


### PR DESCRIPTION
This is a partial revert for f58caf7224807793082b922d368acff03ba76978.


In some cases for unknown reasons, `RunConfig.get()` will begin raising an exception that the config is no longer set.  This should not be happening, and in some instances the problem doesn't show up until a streaming job has been running for hours, but there is likely some underlying issue in Beam/Dataflow that is leading the main session variable to be deleted.

This PR is not intended to be a complete fix, but rather a mitigation that reverts back to `klioexec` getting its config via the `effective-klio-job.yaml` that should be included with the packaged code.

I've left the `klio-cli` changes untouched, meaning it will continue to write a temp file and bind it for use by `klioexec`.  `klioexec` will also still set the `KlioConfig` to the main session variable with `RunConfig.set()`, even though for now it won't be used.

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ ] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
