### PR TITLE
[cli] Fix klio job create for batch job creation

### DIFF
--- a/cli/src/klio_cli/commands/job/create.py
+++ b/cli/src/klio_cli/commands/job/create.py
@@ -344,7 +344,7 @@ class CreateJob(object):
         else:
             if user_input:
                 create_resources = click.prompt(
-                    "Create topics, buckets, and dashboards? [Y/n]",
+                    "Create relevant resources in GCP? [Y/n]",
                     type=click.Choice(["y", "Y", "n", "N"]),
                     default="n"
                     if DEFAULTS["create_resources"] is False
@@ -516,7 +516,7 @@ class CreateJob(object):
         }
 
         if job_type == "batch":
-            job_context = self._get_batch_user_input(kwargs)
+            job_context = self._get_batch_user_input_job_context(kwargs)
         else:
             job_context = self._get_streaming_user_input(kwargs)
 
@@ -582,7 +582,7 @@ class CreateJob(object):
                 "Batch event output file", default=default_batch_event_output
             )
 
-        default_batch_data_output = "{}-output"
+        default_batch_data_output = "{}-output".format(kwargs.get("job_name"))
         batch_data_output = kwargs.get("batch_data_output")
         if not batch_data_output:
             batch_data_output = click.prompt(
@@ -741,7 +741,9 @@ class CreateJob(object):
 
     def _create_external_resources(self, context):
         if context["create_resources"]:
-            gcp_setup.create_topics_and_buckets(context)
+            if context["job_type"] == "streaming":
+                gcp_setup.create_topics(context)
+            gcp_setup.create_buckets(context)
             gcp_setup.create_stackdriver_dashboard(context)
 
     def create(self, unknown_args, known_kwargs, output_dir):

--- a/cli/src/klio_cli/commands/job/utils/gcp_setup.py
+++ b/cli/src/klio_cli/commands/job/utils/gcp_setup.py
@@ -113,7 +113,7 @@ def _create_bucket_if_missing(bucket_name, storage_client, project):
         raise SystemExit(1)
 
 
-def create_topics_and_buckets(context):
+def create_topics(context):
     inputs = context["job_options"]["inputs"]
     outputs = context["job_options"]["outputs"]
     project = context["pipeline_options"]["project"]
@@ -135,11 +135,21 @@ def create_topics_and_buckets(context):
     logging.info(
         "Creating output topics & locations for job {}".format(job_name)
     )
-    storage_client = storage.Client(project=project)
 
     for output in outputs:
         output_topic = output["topic"]
         _create_topic_if_missing(output_topic, publisher_client, project)
+
+
+def create_buckets(context):
+    outputs = context["job_options"]["outputs"]
+    project = context["pipeline_options"]["project"]
+    job_name = context["job_name"]
+
+    logging.info("Creating output locations for job {}".format(job_name))
+    storage_client = storage.Client(project=project)
+
+    for output in outputs:
         location = output["data_location"]
         if not location.startswith("gs://"):
             msg = "Unsupported location type, skipping: {}".format(location)

--- a/cli/tests/commands/job/test_create.py
+++ b/cli/tests/commands/job/test_create.py
@@ -988,8 +988,9 @@ def test_create(
     mock_create_dockerfile = mocker.patch.object(job, "_create_dockerfile")
     mock_create_readme = mocker.patch.object(job, "_create_readme")
 
-    mock_create_topics = mocker.patch.object(
-        create.gcp_setup, "create_topics_and_buckets"
+    mock_create_topics = mocker.patch.object(create.gcp_setup, "create_topics")
+    mock_create_buckets = mocker.patch.object(
+        create.gcp_setup, "create_buckets"
     )
     mock_create_stackdriver = mocker.patch.object(
         create.gcp_setup, "create_stackdriver_dashboard"
@@ -1030,10 +1031,13 @@ def test_create(
         )
 
     if create_resources:
-        mock_create_topics.assert_called_once_with(context)
+        if job_type == "streaming":
+            mock_create_topics.assert_called_once_with(context)
+        mock_create_buckets.assert_called_once_with(context)
         mock_create_stackdriver.assert_called_once_with(context)
     else:
         mock_create_topics.assert_not_called()
+        mock_create_buckets.assert_not_called()
         mock_create_stackdriver.assert_not_called()
 
     mock_create_reqs_files.assert_called_once_with(

--- a/cli/tests/commands/job/utils/test_gcp_setup.py
+++ b/cli/tests/commands/job/utils/test_gcp_setup.py
@@ -229,7 +229,7 @@ def test_create_bucket_if_missing_raises(mock_storage, mocker, caplog):
     assert 2 == len(caplog.records)
 
 
-def test_create_topics_and_buckets(
+def test_create_topics(
     context,
     mock_publisher,
     mock_subscriber,
@@ -238,34 +238,33 @@ def test_create_topics_and_buckets(
     mock_create_storage,
     caplog,
 ):
-    gcp_setup.create_topics_and_buckets(context)
+    gcp_setup.create_topics(context)
 
     assert 1 == mock_publisher.call_count
     assert 1 == mock_subscriber.call_count
     assert 2 == mock_create_topic.call_count
-    assert 1 == mock_storage.call_count
-    assert 1 == mock_create_storage.call_count
     assert 3 == len(caplog.records)
 
 
-def test_create_topics_and_buckets_unsupported(
-    context,
-    mock_publisher,
-    mock_subscriber,
-    mock_storage,
-    mock_create_topic,
-    mock_create_storage,
-    caplog,
+def test_create_buckets(
+    context, mock_storage, mock_create_storage, caplog,
+):
+    gcp_setup.create_buckets(context)
+
+    assert 1 == mock_storage.call_count
+    assert 1 == mock_create_storage.call_count
+    assert 1 == len(caplog.records)
+
+
+def test_create_buckets_unsupported(
+    context, mock_storage, caplog,
 ):
     loc = "bq://not-a-gcs-location"
     context["job_options"]["outputs"][0]["data_location"] = loc
-    gcp_setup.create_topics_and_buckets(context)
+    gcp_setup.create_buckets(context)
 
-    assert 1 == mock_publisher.call_count
-    assert 1 == mock_subscriber.call_count
-    assert 2 == mock_create_topic.call_count
     assert 1 == mock_storage.call_count
-    assert 6 == len(caplog.records)
+    assert 4 == len(caplog.records)
 
 
 def test_create_stackdriver_dashboard(context, mocker, caplog):

--- a/docs/src/reference/cli/changelog.rst
+++ b/docs/src/reference/cli/changelog.rst
@@ -7,6 +7,8 @@ CLI Changelog
 Fixed
 *****
 * Fixed a runtime bug in ``klio job config`` commands
+* Fixed language with ``klio job create`` command to make it more general to job type
+* Fixed bug where ``klio job create`` in batch mode tried to create topics and subscriptions
 
 1.0.4 (2021-01-04)
 ------------------


### PR DESCRIPTION
## Changes
Add more general language to `klio job create` prompts
Fix errors caused by wrong function call when batch job made from cli
Fix `klio job create` so klio will not try to make topics and subscriptions for batch jobs

## Testing
Unit test coverage
Used command to create a batch job and a streaming job

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [x] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [x] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [x] Document any relevant additions/changes in the appropriate spot in `docs/src`.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
