### PR TITLE
[core] Added JSON converter in KlioBigQueryEventOutput

### DIFF
--- a/core/src/klio_core/config/_io.py
+++ b/core/src/klio_core/config/_io.py
@@ -15,6 +15,7 @@
 
 import enum
 import importlib
+import json
 import logging
 
 
@@ -450,12 +451,20 @@ class KlioBigQueryEventInput(KlioEventInput, KlioBigQueryConfig):
         return copy
 
 
+def _convert_bigquery_output_schema(schema):
+    if isinstance(schema, dict):
+        return schema
+    return json.loads(schema)
+
+
 @attr.attrs(frozen=True)
 @supports(KlioIODirection.OUTPUT, KlioIOType.EVENT)
 class KlioBigQueryEventOutput(KlioEventOutput, KlioBigQueryConfig):
     # schema field is optional; assumes form of
     # {"fields": [{"name": ...,"type": ..., "mode": ...}, ... ]
-    schema = attr.attrib(type=dict, default=None)
+    schema = attr.attrib(
+        type=dict, converter=_convert_bigquery_output_schema, default=None
+    )
     create_disposition = attr.attrib(type=str, default="CREATE_IF_NEEDED")
     write_disposition = attr.attrib(type=str, default="WRITE_EMPTY")
 


### PR DESCRIPTION
Description : 
When trying to output my pipeline to BigQuery, my klio job fails because it does not parse the BQ schema in the YAML file into a valid dictionary : 
```
(klio) DMFR0900:data-thumbnails-classification p.genissel$ klio job run --direct-runner --template execution_date="2021-01-10 00:00:00"
INFO:root:Found worker image: gcr.io/dailymotion-rawlogs/data-thumbnails-classification-worker:4c5784c5-dirty
Traceback (most recent call last):
  File "/usr/local/bin/klioexec", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/klio_core/utils.py", line 240, in wrapper
    func(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/klio_exec/cli.py", line 80, in run_pipeline
    if _compare_runtime_to_buildtime_config(klio_config) is False:
  File "/usr/local/lib/python3.6/site-packages/klio_exec/cli.py", line 62, in _compare_runtime_to_buildtime_config
    buildtime_config = config.KlioConfig(_get_config(buildtime_config_path))
  File "/usr/local/lib/python3.6/site-packages/klio_core/config/_utils.py", line 172, in init_from_dict
    self.__config_post_init__(config_dict)
  File "/usr/local/lib/python3.6/site-packages/klio_core/config/core.py", line 51, in __config_post_init__
    self.job_config, job_name=self.job_name, version=self.version,
  File "/usr/local/lib/python3.6/site-packages/klio_core/config/_utils.py", line 172, in init_from_dict
    self.__config_post_init__(config_dict)
  File "/usr/local/lib/python3.6/site-packages/klio_core/config/core.py", line 142, in __config_post_init__
    self._parse_io(config_dict)
  File "/usr/local/lib/python3.6/site-packages/klio_core/config/core.py", line 171, in _parse_io
    io.KlioIODirection.OUTPUT,
  File "/usr/local/lib/python3.6/site-packages/klio_core/config/core.py", line 228, in _create_config_objects
    objs.append(subclass.from_dict(config, io_type, io_direction))
  File "/usr/local/lib/python3.6/site-packages/klio_core/config/_io.py", line 168, in from_dict
    return super().from_dict(copy, *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/klio_core/config/_io.py", line 98, in from_dict
    return cls(*args, **copy, **kwargs)
  File "<attrs generated init klio_core.config._io.KlioBigQueryEventOutput>", line 14, in __init__
  File "/usr/local/lib/python3.6/site-packages/klio_core/config/_io.py", line 456, in check
    has_fields = value.get("fields")
AttributeError: 'str' object has no attribute 'get'

With this PR, I added a converter to the `attr.attrib` method to load the schema variable into a python dictionary when it's a string :)
```

Testing : 
* I successfully ran my job after using this version


## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ X ] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ X ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ X ] Document any relevant additions/changes in the appropriate spot in `docs/src`.
- [ X ] For any change that affects users, update the package's changelog in ``docs/src/reference/<package>/changelog.rst``.

