### PR TITLE
[lib,docs] Deprecate Stackdriver log-based metrics for new native Beam metrics

### DIFF
--- a/docs/src/_static/css/custom.css
+++ b/docs/src/_static/css/custom.css
@@ -74,6 +74,20 @@ div.admonition-collapsible > p.admonition-title.open:before {
   content: "\f107";
 }
 
+/* fixup deprecation directive to look similar to admonitions */
+.deprecated {
+  border-left: 0.2rem solid #dc3545 !important;
+  border-right: None !important;
+  border-top: None !important;
+  border-bottom: None !important;
+
+}
+.versionmodified {
+  border: None !important;
+  font-style: None;
+  font-weight: 700;
+}
+
 /*
   blockquote styling - because apparently pandas theme doesn't include it?
   making it similar to how admonitions look.

--- a/docs/src/reference/lib/api/metrics/index.rst
+++ b/docs/src/reference/lib/api/metrics/index.rst
@@ -6,6 +6,7 @@
    :hidden:
 
    Client <client>
+   Native <native>
    Logger <logger>
    Stackdriver <stackdriver>
    Dispatcher <dispatcher>
@@ -29,6 +30,22 @@
     MetricsRegistry.marshal
     MetricsRegistry.unmarshal
 
+
+:doc:`native`
+^^^^^^^^^^^^^
+
+.. currentmodule:: klio.metrics.native
+
+.. autosummary::
+    :nosignatures:
+
+    NativeMetricsClient
+    NativeMetricsClient.counter
+    NativeMetricsClient.gauge
+    NativeMetricsClient.timer
+    NativeCounter
+    NativeGauge
+    NativeTimer
 
 :doc:`logger`
 ^^^^^^^^^^^^^

--- a/docs/src/reference/lib/api/metrics/native.rst
+++ b/docs/src/reference/lib/api/metrics/native.rst
@@ -1,0 +1,6 @@
+``klio.metrics.native``
+=======================
+
+.. automodule:: klio.metrics.native
+    :members:
+    :exclude-members: unmarshal, emit

--- a/docs/src/reference/lib/changelog.rst
+++ b/docs/src/reference/lib/changelog.rst
@@ -1,6 +1,20 @@
 Changelog
 =========
 
+21.3.0rc1 (UNRELEASED)
+----------------------
+
+Added
+*****
+
+* Add support for using Beam's metrics API directly.
+
+Changed
+*******
+
+* The Beam metrics client will always be used, no matter the configured runner.
+* Marked Klio's support for Stackdriver log-based metrics for deprecation and eventual removal.
+
 0.2.4 (2021-01-14)
 ------------------
 

--- a/docs/src/userguide/pipeline/metrics.rst
+++ b/docs/src/userguide/pipeline/metrics.rst
@@ -12,8 +12,10 @@ Custom User Metrics
 -------------------
 
 Within a Klio transform, you are able to create metric objects during pipeline execution.
-Right now, Klio provides a metrics logger (via the standard library's ``logging`` module),
-and `Stackdriver log-based metrics <https://cloud.google.com/logging/docs/logs-based-metrics/>`_.
+Klio defaults to using `Apache Beam's metrics <https://beam.apache.org/documentation/programming-guide/#metrics>`_ 
+(referred to as "native" metrics within Klio), and additionally provides a metrics logger 
+(via the standard library's :mod:`logging` module), and `Stackdriver log-based metrics 
+<https://cloud.google.com/logging/docs/logs-based-metrics/>`_.
 The Stackdriver log-based metrics client is an overlay of the metrics logger
 where it creates a `user-defined metric <https://console.cloud.google.com/logs/metrics>`_
 within Stackdriver per Python metric object created.
@@ -151,6 +153,9 @@ Setting no metrics configuration is the same as:
 
   job_config:
     metrics:
+      native:
+        # default timer unit in seconds
+        timer_unit: s
       logger:  # default on for Direct Runner
         # level that metrics are emitted
         level: debug
@@ -170,6 +175,11 @@ The default configuration above is the same as setting metrics clients to `True`
     metrics:
       logger: true
       stackdriver_logger: true
+
+
+.. note::
+
+    The native client can not be turned off.
 
 
 To turn off/on a metrics client, set its value to `false`/`true`:
@@ -197,8 +207,22 @@ To turn off/on a metrics client, set its value to `false`/`true`:
 Available Configuration
 ***********************
 
-For both ``logger`` and ``stackdriver_logger``, the following configuration is available:
+For all three clients, ``native``, ``logger`` and ``stackdriver_logger``, the following configuration is available:
 
+
+.. program:: metrics-config
+
+.. option:: timer_unit
+
+  Globally set the default unit of time for timers.
+
+  Options: ``ns``, ``nanoseconds``, ``us``, ``microseconds``, ``ms``, ``milliseconds``,
+  ``s``, ``seconds``.
+
+  Default: ``ns``
+
+
+For both ``logger`` and ``stackdriver_logger``, the following additional configuration is available:
 
 .. program:: metrics-config
 
@@ -209,15 +233,6 @@ For both ``logger`` and ``stackdriver_logger``, the following configuration is a
   Options: ``debug``, ``info``, ``warning``, ``error``, ``critical``.
 
   Default: ``debug``
-
-.. option:: timer_unit
-
-  Globally set the default unit of time for timers.
-
-  Options: ``ns``, ``nanoseconds``, ``us``, ``microseconds``, ``ms``, ``milliseconds``,
-  ``s``, ``seconds``.
-
-  Default: ``ns``
 
 
 Metric Types
@@ -282,6 +297,13 @@ Gauges
     can **only** support counter-type metrics.
     You may still create gauge-type & timer-type metrics,
     but those will only show up in logs, not on Stackdriver.
+
+
+.. warning::
+
+    With the native Beam metrics, when running on Dataflow, only Counter and Distribution type metrics are emitted to Dataflow's monitoring. 
+    See `documentation <https://cloud.google.com/dataflow/docs/guides/using-cloud-monitoring>`_ for more information.
+
 
 A simple integer that is set.
 It reflects a measurement at that point in time

--- a/docs/src/userguide/pipeline/metrics.rst
+++ b/docs/src/userguide/pipeline/metrics.rst
@@ -461,7 +461,7 @@ Right now, Klio only relies on
 <https://cloud.google.com/logging/docs/logs-based-metrics/#counter-metric>`_.
 In the future, Klio may support gauges and/or timers through
 `distribution-type metrics
-<https://cloud.google.com/logging/docs/logs-based-metrics/#distribution_metrics>`_.
+<https://cloud.google.com/logging/docs/logs-based-metrics/#distribution-metric>`_.
 Users are free to experiment with creating distribution metrics by hand based off the logs.
 
 **Metrics between transforms:**

--- a/lib/src/klio/metrics/dispatcher.py
+++ b/lib/src/klio/metrics/dispatcher.py
@@ -128,7 +128,7 @@ class CounterDispatcher(BaseMetricDispatcher):
             value (int): value with which to increment the counter;
                 default is 1.
         """
-        self.value += value
+        self.value = value
 
         for relay, counter in self.relay_to_metric:
             counter.update(self.value)

--- a/lib/src/klio/metrics/native.py
+++ b/lib/src/klio/metrics/native.py
@@ -1,0 +1,238 @@
+# Copyright 2021 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Klio supports Apache Beam's `metrics
+<https://beam.apache.org/documentation/programming-guide/#metrics>`_ via
+:class:`NativeMetricsClient`.
+
+When running on Dataflow, only Counter and Distribution type metrics are
+emitted to Dataflow's monitoring. See `documentation
+<https://cloud.google.com/dataflow/docs/guides/using-cloud-monitoring>`_
+for more information.
+
+This client is used by default regardless of runner, no configuration needed.
+Configuration is supported for the unit of measure for timers objects in
+``klio-job.yaml``:
+
+.. code-block:: yaml
+
+    job_config:
+      metrics:
+        native:
+          # Default timer unit is s/seconds; available
+          # options include `s` or `seconds`, `ms` or `milliseconds`,
+          # `us` or `microseconds`, and `ns` or `nanoseconds`.
+          timer_unit: ms
+
+To configure a different unit of measure than the default for specific timers,
+pass in the desired unit when instantiating. For example:
+
+.. code-block:: python
+
+    class MyTransform(KlioBaseTransform):
+        def __init__(self):
+            self.my_timer = self._klio.metrics.timer(
+                name="my-timer", timer_unit="ns"
+            )
+"""
+import logging
+
+from apache_beam import metrics as beam_metrics
+
+from klio.metrics import base
+
+
+# TODO: pull out into a general module since this is copied from logger.py
+TIMER_UNIT_MAP = {
+    "nanoseconds": "ns",
+    "microseconds": "us",
+    "milliseconds": "ms",
+    "seconds": "s",
+    "ns": "ns",
+    "us": "us",
+    "ms": "ms",
+    "s": "s",
+}
+"""
+Map of supported measurement units to shorthand for :class:`NativeTimer`.
+"""
+
+
+class NativeMetricsClient(base.AbstractRelayClient):
+    """Metrics client for Beam-native metrics collection.
+
+    Intended to be instantiated by :class:`klio.metrics.client.MetricsRegistry`
+    and not by itself.
+
+    Args:
+        klio_config (klio_core.config.KlioConfig): the job's configuration.
+    """
+
+    RELAY_CLIENT_NAME = "beam"
+    # Since these metrics show up on the right sidebar of the Dataflow UI,
+    # let's default to seconds since the usual default of nanoseconds is
+    # a bit unreadable (@lynn).
+    DEFAULT_TIME_UNIT = "s"
+    """Default unit of measurement for timer metrics."""
+
+    def __init__(self, klio_config):
+        super(NativeMetricsClient, self).__init__(klio_config)
+        self.job_name = klio_config.job_name
+        self.native_config = self.klio_config.job_config.metrics.get(
+            "native", {}
+        )
+        self.timer_unit = self._set_timer_unit()
+
+    def _set_timer_unit(self):
+        timer_unit = NativeMetricsClient.DEFAULT_TIME_UNIT
+        if isinstance(self.native_config, dict):
+            _timer_unit = self.native_config.get("timer_unit")
+            if _timer_unit:
+                timer_unit = TIMER_UNIT_MAP.get(_timer_unit, timer_unit)
+        return timer_unit
+
+    def unmarshal(self, metric):
+        # Method is not needed since we're not needing to unmarshal to/from
+        # anywhere (unlike log-based metrics). The method still needs
+        # implementation otherwise we'll get a TypeError when this class
+        # gets instantiated.
+        pass
+
+    def emit(self, metric):
+        # Beam handles the emitting to Dataflow monitoring already, so we
+        # don't need to actually emit anything. The method still needs
+        # implementation otherwise we'll get a TypeError when this class
+        # gets instantiated.
+        pass
+
+    def counter(self, name, transform=None, **kwargs):
+        """Create a :class:`NativeCounter` object.
+
+        Args:
+            name (str): name of counter
+            transform (str): transform the counter is associated with. Defaults
+                to the job's name.
+
+        Returns:
+            NativeCounter: a native counter instance
+        """
+        namespace = transform or self.job_name
+        return NativeCounter(name, namespace=namespace)
+
+    def gauge(self, name, transform=None, **kwargs):
+        """Create a :class:`NativeGauge` object.
+
+        Args:
+            name (str): name of gauge
+            transform (str): transform the gauge is associated with. Defaults
+                to the job's name.
+
+        Returns:
+            NativeGauge: a native gauge instance
+        """
+        logger = logging.getLogger("klio.metrics")
+        logger.warning(
+            "Apache Beam's custom gauge-type metrics are not reported to "
+            "Dataflow's Monitoring service. For more information: "
+            "https://cloud.google.com/dataflow/docs/guides/"
+            "using-cloud-monitoring"
+        )
+
+        namespace = transform or self.job_name
+        return NativeGauge(name, namespace=namespace)
+
+    def timer(self, name, transform=None, timer_unit=None, **kwargs):
+        """Create a :class:`NativeTimer` object.
+
+        Args:
+            name (str): name of timer
+            transform (str): transform the timer is associated with. Defaults
+                to the job's name.
+            timer_unit (str): timer unit; defaults to configured value
+                in `klio-job.yaml`, or
+                :attr:`NativeMetricsClient.DEFAULT_TIME_UNIT`. Options:
+                :attr:`TIMER_UNIT_MAP`.
+
+        Returns:
+            NativeTimer: a native timer instance
+        """
+        namespace = transform or self.job_name
+        if timer_unit:
+            # Note: this should probably have better validation if it does
+            # not recognize the unit given. Instead of erroring out, we'll
+            # just use the default (@lynn)
+            timer_unit = TIMER_UNIT_MAP.get(timer_unit, self.timer_unit)
+        else:
+            timer_unit = self.timer_unit
+        return NativeTimer(name, namespace=namespace, timer_unit=timer_unit)
+
+
+class NativeCounter(base.BaseMetric):
+    """Counter metric using Beam's `counter-type metric
+    <https://beam.apache.org/documentation/programming-guide/
+    #types-of-metrics>`_.
+
+    Args:
+        name (str): name of counter
+        namespace (str): Name of namespace the counter belongs to (e.g.
+            the counter's transform).
+    """
+
+    def __init__(self, name, namespace):
+        self._counter = beam_metrics.Metrics.counter(namespace, name)
+
+    def update(self, value):
+        self._counter.inc(value)
+
+
+class NativeGauge(base.BaseMetric):
+    """Gauge metric using Beam's `gauge-type metric
+    <https://beam.apache.org/documentation/programming-guide/
+    #types-of-metrics>`_.
+
+    Args:
+        name (str): name of gauge
+        namespace (str): Name of namespace the gauge belongs to (e.g.
+            the gauge's transform).
+    """
+
+    def __init__(self, name, namespace):
+        self._gauge = beam_metrics.Metrics.gauge(namespace, name)
+
+    def update(self, value):
+        self._gauge.set(value)
+
+
+class NativeTimer(base.BaseMetric):
+    """Timer metric using Beam's `distribution-type metric
+    <https://beam.apache.org/documentation/programming-guide/
+    #types-of-metrics>`_.
+
+    Args:
+        name (str): name of timer
+        namespace (str): Name of namespace the timer belongs to (e.g.
+            the timer's transform).
+        timer_unit (str): Unit of measurement. Options:
+            :attr:`TIMER_UNIT_MAP`.
+            Default: ``ns`` (nanoseconds).
+    """
+
+    def __init__(self, name, namespace, timer_unit="ns"):
+        self._timer = beam_metrics.Metrics.distribution(namespace, name)
+        self.timer_unit = timer_unit
+
+    def update(self, value):
+        # TODO: how is timer unit(s) handled?
+        self._timer.update(value)

--- a/lib/src/klio/metrics/stackdriver.py
+++ b/lib/src/klio/metrics/stackdriver.py
@@ -33,6 +33,9 @@ To explicitly turn off log-based metrics, in ``klio-job.yaml``:
       metrics:
         stackdriver_logger: false
 
+.. deprecated:: 21.3.0
+    Use :mod:`native <klio.metrics.native>` metrics instead. See
+    :ref:`docs <stackdriver-log-metrics-deprecation-notice>` for more info.
 """
 import logging
 
@@ -40,8 +43,14 @@ from googleapiclient import discovery
 from googleapiclient import errors as gapi_errors
 
 from klio.metrics import logger
+from klio.transforms import _utils
 
 
+BASE_WARN_MSG = " has been deprecated since `klio` version 21.3.0"
+
+
+# FYI: marking the __init__ method as deprecated instead of the class since
+#      (for now) the decorator doesn't work on classes.
 class StackdriverLogMetricsClient(logger.MetricsLoggerClient):
     """Stackdriver client for transform metrics.
 
@@ -50,10 +59,16 @@ class StackdriverLogMetricsClient(logger.MetricsLoggerClient):
 
     Args:
         klio_config (klio_core.config.KlioConfig):  the job's configuration.
+
+    .. deprecated:: 21.3.0
+       Use :class:`NativeMetricsClient
+       <klio.metrics.native.NativeMetricsClient>` instead. See
+       :ref:`docs <stackdriver-log-metrics-deprecation-notice>` for more info.
     """
 
     RELAY_CLIENT_NAME = "stackdriver_logger"
 
+    @_utils.deprecated(message="StackdriverLogMetricsClient" + BASE_WARN_MSG)
     def __init__(self, klio_config):
         super(StackdriverLogMetricsClient, self).__init__(klio_config)
         self.job_name = klio_config.job_name
@@ -155,6 +170,8 @@ class StackdriverLogMetricsClient(logger.MetricsLoggerClient):
         return StackdriverLogMetricsTimer(*args, **kwargs)
 
 
+# FYI: marking the __init__ method as deprecated instead of the class since
+#      (for now) the decorator doesn't work on classes.
 class StackdriverLogMetricsCounter(logger.LoggerCounter):
     """Stackdriver log-based counter metric.
 
@@ -170,6 +187,11 @@ class StackdriverLogMetricsCounter(logger.LoggerCounter):
         transform (str): Name of transform associated with counter, if any.
         tags (dict): Tags to associate with counter. Note:
             ``{"metric_type": "counter"}`` will always be an included tag.
+
+    .. deprecated:: 21.3.0
+        Use :class:`NativeCounter <klio.metrics.native.NativeCounter>` instead.
+        See :ref:`docs <stackdriver-log-metrics-deprecation-notice>` for more
+        info.
     """
 
     # NOTE: The in-memory value (as kept track in the metric Dispatchers) may
@@ -184,6 +206,7 @@ class StackdriverLogMetricsCounter(logger.LoggerCounter):
     )
     KLIO_TRANSFORM_LABEL_KEY = "klio_transform"
 
+    @_utils.deprecated(message="StackdriverLogMetricsCounter" + BASE_WARN_MSG)
     def __init__(self, name, job_name, project, transform=None, tags=None):
         # Since stackdriver literally counts loglines, initializing a
         # counter value is not supported; defaulting to 0
@@ -278,13 +301,35 @@ class StackdriverLogMetricsCounter(logger.LoggerCounter):
     # including method for documentation purposes
 
 
+# FYI: marking the __init__ method as deprecated instead of the class since
+#      (for now) the decorator doesn't work on classes.
 class StackdriverLogMetricsGauge(logger.LoggerGauge):
     """Pass-thru object for naming only. Stackdriver log-based metrics
     does not support gauges.
+
+    .. deprecated:: 21.3.0
+        Use :class:`NativeGauge <klio.metrics.native.NativeGauge>` instead.
+        See :ref:`docs <stackdriver-log-metrics-deprecation-notice>` for more
+        info.
     """
 
+    @_utils.deprecated(message="StackdriverLogMetricsGauge" + BASE_WARN_MSG)
+    def __init__(self, *args, **kwargs):
+        super(StackdriverLogMetricsGauge, self).__init__(*args, **kwargs)
 
+
+# FYI: marking the __init__ method as deprecated instead of the class since
+#      (for now) the decorator doesn't work on classes.
 class StackdriverLogMetricsTimer(logger.LoggerTimer):
     """Pass-thru object for naming only. Stackdriver log-based metrics
     does not support timers.
+
+    .. deprecated:: 21.3.0
+        Use :class:`NativeTimer <klio.metrics.native.NativeTimer>` instead.
+        See :ref:`docs <stackdriver-log-metrics-deprecation-notice>` for more
+        info.
     """
+
+    @_utils.deprecated(message="StackdriverLogMetricsTimer" + BASE_WARN_MSG)
+    def __init__(self, *args, **kwargs):
+        super(StackdriverLogMetricsTimer, self).__init__(*args, **kwargs)

--- a/lib/src/klio/transforms/core.py
+++ b/lib/src/klio/transforms/core.py
@@ -26,6 +26,7 @@ from klio_core.proto import klio_pb2
 
 from klio.metrics import client as metrics_client
 from klio.metrics import logger as metrics_logger
+from klio.metrics import native as native_metrics
 from klio.metrics import stackdriver
 
 
@@ -100,7 +101,8 @@ class KlioContext(object):
         return klio_job_str
 
     def _get_metrics_registry(self):
-        clients = []
+        native_metrics_client = native_metrics.NativeMetricsClient(self.config)
+        clients = [native_metrics_client]
         use_logger, use_stackdriver = None, None
         metrics_config = self.config.job_config.metrics
 
@@ -114,34 +116,33 @@ class KlioContext(object):
         #       `--direct-runner`.
         #       i.e.: runner = os.getenv("BEAM_RUNNER", "").lower()
         runner = self.config.pipeline_options.runner
+
         if "dataflow" in runner.lower():
-            # Must explicitly compare to `False` since `None` could be
-            # the user accepting default config.
-            # If explicitly false, then just disable logger underneath SD
-            if use_stackdriver is not False:
-                sd_client = stackdriver.StackdriverLogMetricsClient(
-                    self.config
-                )
-                clients.append(sd_client)
-            else:
-                # if use_stackdriver is explicitly false, then make sure
-                # logger client is disabled since the stackdriver client
-                # inherits the logger client
+            if use_logger is None:
                 use_logger = False
 
-        if not len(clients):  # setup default client
-            disabled = False
-            # User might disable the logger, but we still need a relay
-            # client if all other relay clients are disabled. This allows
-            # folks to silence metrics but not need to remove code that
-            # interacts with `_klio.metrics`.
-            # Must explicitly compare to `False` since `None` could be
-            # the user accepting default config
-            if use_logger is False:
-                disabled = True
-            logger_client = metrics_logger.MetricsLoggerClient(
-                self.config, disabled=disabled
-            )
+            if use_stackdriver is None:
+                use_stackdriver = True
+            # if use_stackdriver is explicitly False, then make sure
+            # logger client is disabled since the stackdriver client
+            # inherits the logger client
+            elif use_stackdriver is False:
+                use_logger = False
+
+        else:
+            if use_logger is None:
+                use_logger = True
+            if use_stackdriver is not False:
+                # Explicitly turn it off when not running on Dataflow as SD
+                # metrics reporting doesn't work when running locally
+                use_stackdriver = False
+
+        if use_stackdriver is not False:
+            sd_client = stackdriver.StackdriverLogMetricsClient(self.config)
+            clients.append(sd_client)
+
+        if use_logger is not False:
+            logger_client = metrics_logger.MetricsLoggerClient(self.config)
             clients.append(logger_client)
 
         return metrics_client.MetricsRegistry(

--- a/lib/src/klio/transforms/core.py
+++ b/lib/src/klio/transforms/core.py
@@ -138,6 +138,8 @@ class KlioContext(object):
                 use_stackdriver = False
 
         if use_stackdriver is not False:
+            # FYI there's a deprecation warning when the SD Client is init'ed
+            # StackdriverLogMetricsClient is init'ed
             sd_client = stackdriver.StackdriverLogMetricsClient(self.config)
             clients.append(sd_client)
 

--- a/lib/tests/unit/metrics/test_native.py
+++ b/lib/tests/unit/metrics/test_native.py
@@ -1,0 +1,123 @@
+# Copyright 2021 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+
+from apache_beam import metrics as beam_metrics
+
+from klio.metrics import native
+
+
+@pytest.fixture
+def client(klio_config):
+    return native.NativeMetricsClient(klio_config)
+
+
+@pytest.mark.parametrize(
+    "transform,exp_namespace",
+    ((None, "test-job"), ("test-transform", "test-transform")),
+)
+def test_client_counter(transform, exp_namespace, client, mocker, monkeypatch):
+    counter = client.counter(name="my-counter", transform=transform)
+
+    assert isinstance(counter, native.NativeCounter)
+    assert isinstance(counter._counter, beam_metrics.metricbase.Counter)
+    assert exp_namespace == counter._counter.metric_name.namespace
+    assert "my-counter" == counter._counter.metric_name.name
+
+    mock_inc = mocker.Mock()
+    monkeypatch.setattr(counter._counter, "inc", mock_inc)
+    counter.update(1)
+
+    mock_inc.assert_called_once_with(1)
+
+
+@pytest.mark.parametrize(
+    "transform,exp_namespace",
+    ((None, "test-job"), ("test-transform", "test-transform")),
+)
+def test_client_gauge(transform, exp_namespace, client, mocker, monkeypatch):
+    gauge = client.gauge(name="my-gauge", transform=transform)
+
+    assert isinstance(gauge, native.NativeGauge)
+    assert isinstance(gauge._gauge, beam_metrics.metricbase.Gauge)
+    assert exp_namespace == gauge._gauge.metric_name.namespace
+    assert "my-gauge" == gauge._gauge.metric_name.name
+
+    mock_set = mocker.Mock()
+    monkeypatch.setattr(gauge._gauge, "set", mock_set)
+    gauge.update(1)
+
+    mock_set.assert_called_once_with(1)
+
+
+@pytest.mark.parametrize(
+    "timer_unit,exp_timer_unit",
+    ((None, "s"), ("nanoseconds", "ns"), ("ms", "ms")),
+)
+@pytest.mark.parametrize(
+    "transform,exp_namespace",
+    ((None, "test-job"), ("test-transform", "test-transform")),
+)
+def test_client_timer(
+    transform,
+    exp_namespace,
+    timer_unit,
+    exp_timer_unit,
+    client,
+    mocker,
+    monkeypatch,
+):
+    timer = client.timer(
+        name="my-timer", transform=transform, timer_unit=timer_unit
+    )
+
+    assert isinstance(timer, native.NativeTimer)
+    assert isinstance(timer._timer, beam_metrics.metricbase.Distribution)
+    assert exp_namespace == timer._timer.metric_name.namespace
+    assert "my-timer" == timer._timer.metric_name.name
+    assert exp_timer_unit == timer.timer_unit
+
+    mock_update = mocker.Mock()
+    monkeypatch.setattr(timer._timer, "update", mock_update)
+    timer.update(1)
+
+    mock_update.assert_called_once_with(1)
+
+
+# just to get 100% coverage for the module
+def test_client_instance(client):
+    assert "beam" == client.RELAY_CLIENT_NAME
+    assert "s" == client.DEFAULT_TIME_UNIT
+
+    assert client.unmarshal("metric") is None
+    assert client.emit("metric") is None
+
+
+@pytest.mark.parametrize(
+    "metrics_config,exp_timer_unit",
+    (
+        ({}, "s"),
+        ({"native": None}, "s"),
+        ({"native": {"timer_unit": "nanoseconds"}}, "ns"),
+        ({"native": {"timer_unit": "ms"}}, "ms"),
+        ({"logger": {"timer_unit": "notaunit"}}, "s"),
+    ),
+)
+def test_client_set_timer_unit(metrics_config, exp_timer_unit, klio_config):
+    klio_config.job_config.metrics = metrics_config
+    client = native.NativeMetricsClient(klio_config)
+
+    assert exp_timer_unit == client.timer_unit

--- a/lib/tests/unit/metrics/test_stackdriver.py
+++ b/lib/tests/unit/metrics/test_stackdriver.py
@@ -20,6 +20,13 @@ from googleapiclient import errors as gapi_errors
 from klio.metrics import stackdriver as sd_metrics
 
 
+BASE_WARN_MSG = " has been deprecated since `klio` version 21.3.0"
+CLIENT_WARN_MSG = "StackdriverLogMetricsClient" + BASE_WARN_MSG
+CTR_WARN_MSG = "StackdriverLogMetricsCounter" + BASE_WARN_MSG
+GAUGE_WARN_MSG = "StackdriverLogMetricsGauge" + BASE_WARN_MSG
+TIMER_WARN_MSG = "StackdriverLogMetricsTimer" + BASE_WARN_MSG
+
+
 @pytest.fixture
 def mock_stackdriver_client(mocker, monkeypatch):
     mock_client = mocker.Mock()
@@ -51,6 +58,7 @@ def counter():
     return sd_metrics.StackdriverLogMetricsCounter(**kwargs)
 
 
+@pytest.mark.filterwarnings(f"ignore:{CLIENT_WARN_MSG}")
 def test_stackdriver_client(client, mock_discovery_build):
     # sanity check
     assert not getattr(client._thread_local, "stackdriver_client", None)
@@ -62,6 +70,8 @@ def test_stackdriver_client(client, mock_discovery_build):
 
 
 @pytest.mark.parametrize("value", (None, 5))
+@pytest.mark.filterwarnings(f"ignore:{CLIENT_WARN_MSG}")
+@pytest.mark.filterwarnings(f"ignore:{CTR_WARN_MSG}")
 def test_client_counter(client, value, mocker, monkeypatch, caplog):
     mock_init_metric = mocker.Mock()
     monkeypatch.setattr(
@@ -84,6 +94,8 @@ def test_client_counter(client, value, mocker, monkeypatch, caplog):
         assert "WARNING" == caplog.records[0].levelname
 
 
+@pytest.mark.filterwarnings(f"ignore:{CLIENT_WARN_MSG}")
+@pytest.mark.filterwarnings(f"ignore:{GAUGE_WARN_MSG}")
 def test_client_gauge(client, caplog):
     gauge = client.gauge(name="my-gauge")
 
@@ -92,6 +104,8 @@ def test_client_gauge(client, caplog):
     assert "WARNING" == caplog.records[0].levelname
 
 
+@pytest.mark.filterwarnings(f"ignore:{CLIENT_WARN_MSG}")
+@pytest.mark.filterwarnings(f"ignore:{TIMER_WARN_MSG}")
 def test_client_timer(client, caplog):
     gauge = client.timer(name="my-timer")
 
@@ -100,6 +114,7 @@ def test_client_timer(client, caplog):
     assert "WARNING" == caplog.records[0].levelname
 
 
+@pytest.mark.filterwarnings(f"ignore:{CTR_WARN_MSG}")
 def test_counter_get_filter(counter):
     exp_filter = (
         'resource.type="dataflow_step" '
@@ -113,6 +128,7 @@ def test_counter_get_filter(counter):
 
 
 @pytest.mark.parametrize("raises", (False, True))
+@pytest.mark.filterwarnings(f"ignore:{CTR_WARN_MSG}")
 def test_counter_init_metric(raises, counter, mock_stackdriver_client, caplog):
     _mock_projects = mock_stackdriver_client.projects.return_value
     mock_req = _mock_projects.metrics.return_value.create
@@ -132,6 +148,7 @@ def test_counter_init_metric(raises, counter, mock_stackdriver_client, caplog):
 @pytest.mark.parametrize(
     "status,exp_log_level", ((409, "DEBUG"), (403, "ERROR"))
 )
+@pytest.mark.filterwarnings(f"ignore:{CTR_WARN_MSG}")
 def test_counter_init_metric_api_error(
     status, exp_log_level, counter, mock_stackdriver_client, mocker, caplog
 ):

--- a/lib/tests/unit/transforms/test_core.py
+++ b/lib/tests/unit/transforms/test_core.py
@@ -65,6 +65,12 @@ from klio.transforms import core as core_transforms
         ),
     ),
 )
+@pytest.mark.filterwarnings(
+    (
+        "ignore:StackdriverLogMetricsClient has been deprecated since `klio` "
+        "version 0.2.6"
+    )
+)
 def test_klio_metrics(
     runner,
     metrics_config,

--- a/lib/tests/unit/transforms/test_decorators.py
+++ b/lib/tests/unit/transforms/test_decorators.py
@@ -87,6 +87,12 @@ def test_retry_custom_catch(kmsg, mocker, mock_config):
     assert 1 == mock_function.call_count
 
 
+@pytest.mark.filterwarnings(
+    (
+        "ignore:'retry' is experimental and is subject to incompatible "
+        "changes, or removal in a future release of Klio."
+    )
+)
 def test_retry_raises_runtime_parents(kmsg, mocker, mock_config):
     # Need to call @retry with parens
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
<!--- Describe your changes 

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

For some reason, the ability to create custom log metrics in Stackdriver no longer works. Rather than spending time trying to understand why and how to fix it, now that Dataflow supports collecting metrics from Beam's native metrics implementation (so beam metrics are automatically emitted to and reported by Dataflow's monitoring when running on Dataflow), I've decided to leverage that instead and mark the Stackdriver log-based metrics as deprecated.

I went on the assumption that we could make a March release (`21.3.0`) but it's just a placeholder - doesn't have to be for our March release.

The next steps after this:
* Add metrics that are reported by default from our library of transforms (e.g. message consumed, message processed, message errored, message retried, message processed time);
* Add support for programmatically creating graphs & dashboards via the `klio-cli` to easily capture those default metrics;
* Deprecate/remove the current dashboard creation mechanism (the new approach will be far more helpful)
* [if possible] Defining default alerts and programmatically creating them in Stackdriver

<!--- How have you tested this?
Some valid responses are:

* "I have included unit tests" 
* "I have included integration tests"
* "I successfully ran my jobs with this code"

-->

* "I have included unit tests"
* "I successfully ran my jobs with this code"

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [x] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [x] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [x] Document any relevant additions/changes in the appropriate spot in `docs/src`.
- [x] For any change that affects users, update the package's changelog in ``docs/src/reference/<package>/changelog.rst``.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
