### PR TITLE
[cli] Enable job test command to use the --config-file option

### DIFF
--- a/cli/src/klio_cli/commands/job/test.py
+++ b/cli/src/klio_cli/commands/job/test.py
@@ -21,12 +21,23 @@ class TestPipeline(base.BaseDockerizedPipeline):
 
     def __init__(self, job_dir, klio_config, docker_runtime_config):
         super().__init__(job_dir, klio_config, docker_runtime_config)
-        self.requires_config_file = False
+        self.requires_config_file = True
 
     def _get_environment(self):
         envs = super()._get_environment()
         envs["KLIO_TEST_MODE"] = "true"
         return envs
 
-    def _get_command(self, pytest_args):
-        return ["test"] + pytest_args
+    def _get_command(self, *args, **kwargs):
+        return ["test"]
+
+    def _add_pytest_args(self, cmd, pytest_args):
+        if pytest_args:
+            cmd.extend(pytest_args)
+
+    def _get_docker_runflags(self, *args, **kwargs):
+        base_runflags = super()._get_docker_runflags(*args, **kwargs)
+        # add pytest args *after* the base command flags are added
+        pytest_args = kwargs.get("pytest_args", [])
+        self._add_pytest_args(base_runflags["command"], pytest_args)
+        return base_runflags

--- a/cli/tests/commands/job/test_test.py
+++ b/cli/tests/commands/job/test_test.py
@@ -42,8 +42,32 @@ def test_get_environment(test_pipeline):
 
 
 def test_get_command(test_pipeline):
-    assert ["test", "py", "args"] == test_pipeline._get_command(["py", "args"])
+    assert ["test"] == test_pipeline._get_command()
+
+
+def test_add_pytest_args(test_pipeline):
+    docker_runflags = {"command": ["cmd"]}
+    test_pipeline._add_pytest_args(docker_runflags["command"], ["py", "args"])
+    assert ["cmd", "py", "args"] == docker_runflags["command"]
+
+
+def test_get_docker_runflags(mocker, monkeypatch, test_pipeline):
+    mock_base_docker_runflags = mocker.Mock()
+    mock_base_docker_runflags.return_value = {
+        "command": ["test", "--config-file", "x"]
+    }
+    monkeypatch.setattr(
+        test_job.base.BaseDockerizedPipeline,
+        "_get_docker_runflags",
+        mock_base_docker_runflags,
+    )
+    actual_runflags = test_pipeline._get_docker_runflags(
+        pytest_args=["py", "args"]
+    )
+
+    expected = ["test", "--config-file", "x", "py", "args"]
+    assert expected == actual_runflags["command"]
 
 
 def test_requires_config_setting(test_pipeline):
-    assert not test_pipeline.requires_config_file
+    assert test_pipeline.requires_config_file


### PR DESCRIPTION
`klio job test` currently takes in the `--config-file` option but does nothing with it, since the `requires_config_file` flag is set to `False`. 

The config file option was also ignored in `klio-exec`, but that was fixed via [PR 177](https://github.com/spotify/klio/pull/177).

This PR sets enables the use of the `--config-file` option by doing 2 things:

1. Setting `TestPipeline().requires_config_file` to `True`. 
2. This PR also adjusts the way `TestPipeline` handles command generation so that the `--config-file` option is appended after the `test` command, but before pytest arguments are added. 

Before this change, the generated command would be: 

```klio job test -- py_arg1 pyarg2 ... pyargN --config-file config.yaml```

This causes the `--config-file` option to be ignored. 

After this change, the generated command would be:

```klio job test --config-file config.yaml -- py_arg1 pyarg 2 .. pyargN```

<!--- How have you tested this?
Some valid responses are:
* "I have included unit tests" 
-->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [x] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [x] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [x] Document any relevant additions/changes in the appropriate spot in `docs/src`.
- [x] For any change that affects users, update the package's changelog in ``docs/src/reference/<package>/changelog.rst``.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
