### PR TITLE
[cli] effective config is properly written for profile commands

### DIFF
--- a/cli/src/klio_cli/commands/job/profile.py
+++ b/cli/src/klio_cli/commands/job/profile.py
@@ -111,6 +111,7 @@ class ProfilePipeline(base.BaseDockerizedPipeline):
 
     def run(self, what, subcommand_flags):
         self._check_docker_setup()
+        self._write_effective_config()
         self._setup_docker_image()
 
         kwargs = {"subcommand": what, "subcommand_flags": subcommand_flags}

--- a/cli/tests/commands/job/test_profile.py
+++ b/cli/tests/commands/job/test_profile.py
@@ -339,6 +339,10 @@ def test_run(klio_pipeline, mocker, monkeypatch):
     monkeypatch.setattr(
         klio_pipeline, "_run_docker_container", mock_run_docker_container
     )
+    mock_write_effective_config = mocker.Mock()
+    monkeypatch.setattr(
+        klio_pipeline, "_write_effective_config", mock_write_effective_config
+    )
 
     klio_pipeline.run(what="what", subcommand_flags={"some": "flags"})
 
@@ -350,6 +354,7 @@ def test_run(klio_pipeline, mocker, monkeypatch):
     mock_run_docker_container.assert_called_once_with(
         mock_get_docker_runflags.return_value
     )
+    mock_write_effective_config.assert_called_once_with()
 
 
 @pytest.mark.parametrize("input_file", (None, "foo.pstats"))


### PR DESCRIPTION
Since `ProfilePipeline` overrides `run` and was missing the call to `_write_effective_config()`, `klio job profile` commands were erroring out if `klio-job-run-effective.yaml` was missing.  This PR just adds the call to fix the issue.

Note: I took a quick look at perhaps changing where this call is managed, so sub-classes overriding `run` wouldn't have to worry about it, but since `profile` is the only such command I decided not to over complicate things for now.

<!--- How have you tested this?
Some valid responses are:

* "I have included unit tests" 
* "I have included integration tests"
* "I successfully ran my jobs with this code"

-->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ ] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Document any relevant additions/changes in the appropriate spot in `docs/src`.
- [ ] For any change that affects users, update the package's changelog in ``docs/src/reference/<package>/changelog.rst``.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
