### PR TITLE
[exec] Fixed multiple event inputs

### DIFF
--- a/exec/src/klio_exec/commands/run.py
+++ b/exec/src/klio_exec/commands/run.py
@@ -485,7 +485,7 @@ class KlioPipeline(object):
         to_process = MultiInputPCollTuple(**input_name_to_input_pcolls)
         to_pass_thru = (
             multi_to_pass_thru
-            | "Merge multi-input pass-thrus" >> beam.Flatten()
+            | "Merge multi-input pass-thrus" >> beam.Flatten(pipeline=pipeline)
         )
         return to_process, to_pass_thru
 


### PR DESCRIPTION
Hello ! 

I have an error when I use multiple event inputs like this in my Klio job : 

```
job_config:
  allow_non_klio_messages: True
  events:
    inputs:
      - type: pubsub
        topic: projects/my-project/topics/oplog-high-latency
        subscription: projects/my-project/subscriptions/frames-input
      - type: pubsub
        topic: projects/my-project/topics/oplog-high-latency
        subscription: projects/my-project/subscriptions/frames-input

```

Here is the error I get when I do a `klio job run`: 

```
Traceback (most recent call last):
  File "/usr/local/bin/klioexec", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/klio_core/utils.py", line 238, in wrapper
    func(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/klio_exec/cli.py", line 95, in run_pipeline
    klio_pipeline.run()
  File "/usr/local/lib/python3.6/site-packages/klio_exec/commands/run.py", line 556, in run
    self._setup_pipeline(pipeline)
  File "/usr/local/lib/python3.6/site-packages/klio_exec/commands/run.py", line 529, in _setup_pipeline
    pipeline
  File "/usr/local/lib/python3.6/site-packages/klio_exec/commands/run.py", line 488, in _generate_pcoll_per_input
    | "Merge multi-input pass-thrus" >> beam.Flatten()
  File "/usr/local/lib/python3.6/site-packages/apache_beam/transforms/ptransform.py", line 1036, in __ror__
    return self.transform.__ror__(pvalueish, self.label)
  File "/usr/local/lib/python3.6/site-packages/apache_beam/transforms/ptransform.py", line 553, in __ror__
    'as there are no deferred inputs.' % self.label)
ValueError: "Flatten" requires a pipeline to be specified as there are no deferred inputs.
```

I have successfully ran my jobs with this fix.

Thank you in advance for taking a look into it :) 

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [x] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [x] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [x] Document any relevant additions/changes in the appropriate spot in `docs/src`.
- [x] For any change that affects users, update the package's changelog in ``docs/src/reference/<package>/changelog.rst``.

