### PR TITLE
fix outputs.skip_klio_existence_check with pipeline without inputs

### DIFF
--- a/exec/src/klio_exec/commands/run.py
+++ b/exec/src/klio_exec/commands/run.py
@@ -380,11 +380,15 @@ class KlioPipeline(object):
                 output_exists.found
                 | lbl("Output Force Filter") >> helpers.KlioFilterForce()
             )
-            to_pass_thru_tuple = (pass_thru, output_force.pass_thru)
-            to_pass_thru = (
-                to_pass_thru_tuple
-                | lbl("Flatten to Pass Thru") >> beam.Flatten()
-            )
+            
+            if pass_thru is not None:
+                to_pass_thru_tuple = (pass_thru, output_force.pass_thru)
+                to_pass_thru = (
+                    to_pass_thru_tuple
+                    | lbl("Flatten to Pass Thru") >> beam.Flatten()
+                )
+            else:
+                to_pass_thru = output_force.pass_thru
 
             to_filter_input_tuple = (
                 output_exists.not_found,


### PR DESCRIPTION
With the following job_config : 

```yaml
  data:
    outputs:
      - type: gcs
        location: gs://data-usc1-audio-stg/audio-tmp-delete-me-pls
        file_suffix: .wav
        skip_klio_existence_check: False
```
we get this error :
```
NotImplementedError: Unable to extract PValue inputs from (None, <PCollection[Output Force Filter/ParDo(KlioFilterForce).pass_thru] at 0x7f5e228f5cf8>); either <Flatten(PTransform) label=[Flatten to Pass Thru]> does not accept inputs of this format, or it does not properly override _extract_input_pvalues
```

This pr fix the issue by not using the flatten step when pass_thru is None.

<!--- Describe your changes 

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

<!--- How have you tested this?
Some valid responses are:

* "I have included unit tests" 
* "I have included integration tests"
* "I successfully ran my jobs with this code"

-->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ ] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Document any relevant additions/changes in the appropriate spot in `docs/src`.
- [ ] For any change that affects users, update the package's changelog in ``docs/src/reference/<package>/changelog.rst``.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
