### PR TITLE
[cli] klio message publish blocks on pubsub client future

### DIFF
--- a/cli/src/klio_cli/commands/message/publish.py
+++ b/cli/src/klio_cli/commands/message/publish.py
@@ -89,7 +89,9 @@ def _publish_messages(
             message = bytes(entity_id.encode("utf-8"))
 
         try:
-            publish(data=message)
+            future = publish(data=message)
+            # block until message is published or exception is raised
+            future.result()
             success_ids.append(entity_id)
 
         except Exception as e:

--- a/docs/src/faqs/performance.rst
+++ b/docs/src/faqs/performance.rst
@@ -1,4 +1,4 @@
 What's the performance of a Klio pipeline?
 ==========================================
 
-As a simple test, we've `downsampled <https://en.wikipedia.org/wiki/Downsampling_(signal_processing)>`_ 10s of millions of songs in :violetemph:`6 days` using 600 `n1-standard-16 <https://cloud.google.com/compute/docs/machine-types#n1_machine_types>`_ machines (16 vCPUs, 60GB memory).
+As a simple test, we've `downsampled <https://en.wikipedia.org/wiki/Downsampling_(signal_processing)>`_ 10s of millions of songs in :violetemph:`6 days` using 600 `n1-standard-16 <https://cloud.google.com/compute/docs/machine-types#machine_types>`_ machines (16 vCPUs, 60GB memory).

--- a/docs/src/reference/cli/changelog.rst
+++ b/docs/src/reference/cli/changelog.rst
@@ -1,6 +1,14 @@
 CLI Changelog
 =============
 
+21.7.0 (UNRELEASED)
+-------------------
+
+Fixed
+*****
+
+* Fixed bug with ``klio message publish`` not working on ``google-cloud-pubsub > 2.3.0``
+
 .. _cli-21.2.0:
 
 21.2.0 (2021-03-16)


### PR DESCRIPTION
When using `google-cloud-pubsub` `2.5.0`, `klio message publish` will say that the message is successfully published, but the message is not actually published to the topic.  This appears to have been some underlying threading change causing a race condition where `klio-cli` doesn't wait on the returned `Future` and exits before the message is actually published.

Simply blocking on the future fixes the issue.  I tested with pubsub `2.0.0`, `2.3.0` and `2.5.0`.

This is just a quick fix and there is room for further improvement.  If multiple messages are being published, this will end up blocking for each message, which is a bit inefficient since the pubsub client does have internal batching capabilities, but for small numbers of messages it shouldn't be big deal.

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ ] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Document any relevant additions/changes in the appropriate spot in `docs/src`.
- [ ] For any change that affects users, update the package's changelog in ``docs/src/reference/<package>/changelog.rst``.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
