### PR TITLE
release 21.7.0.dev2

### DIFF
--- a/cli/setup.cfg
+++ b/cli/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 21.7.0.dev1
+current_version = 21.7.0.dev2
 tag_name = cli-{new_version}
 commit = True
 tag = True

--- a/cli/src/klio_cli/__init__.py
+++ b/cli/src/klio_cli/__init__.py
@@ -14,7 +14,7 @@
 #
 
 __author__ = "The klio developers"
-__version__ = "21.7.0.dev1"
+__version__ = "21.7.0.dev2"
 __email__ = "opensource+klio@spotify.com"
 __description__ = "Main entrypoint for Klio jobs"
 __uri__ = "https://github.com/spotify/klio"

--- a/cli/src/klio_cli/commands/message/publish.py
+++ b/cli/src/klio_cli/commands/message/publish.py
@@ -89,7 +89,9 @@ def _publish_messages(
             message = bytes(entity_id.encode("utf-8"))
 
         try:
-            publish(data=message)
+            future = publish(data=message)
+            # block until message is published or exception is raised
+            future.result()
             success_ids.append(entity_id)
 
         except Exception as e:

--- a/core/setup.cfg
+++ b/core/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 21.7.0.dev1
+current_version = 21.7.0.dev2
 commit = True
 tag = True
 tag_name = core-{new_version}

--- a/core/src/klio_core/__init__.py
+++ b/core/src/klio_core/__init__.py
@@ -14,7 +14,7 @@
 #
 
 __author__ = "The klio developers"
-__version__ = "21.7.0.dev1"
+__version__ = "21.7.0.dev2"
 __email__ = "opensource+klio@spotify.com"
 __description__ = "Core klio library for common functionality"
 __uri__ = "https://github.com/spotify/klio"

--- a/docs/src/faqs/performance.rst
+++ b/docs/src/faqs/performance.rst
@@ -1,4 +1,4 @@
 What's the performance of a Klio pipeline?
 ==========================================
 
-As a simple test, we've `downsampled <https://en.wikipedia.org/wiki/Downsampling_(signal_processing)>`_ 10s of millions of songs in :violetemph:`6 days` using 600 `n1-standard-16 <https://cloud.google.com/compute/docs/machine-types#n1_machine_types>`_ machines (16 vCPUs, 60GB memory).
+As a simple test, we've `downsampled <https://en.wikipedia.org/wiki/Downsampling_(signal_processing)>`_ 10s of millions of songs in :violetemph:`6 days` using 600 `n1-standard-16 <https://cloud.google.com/compute/docs/machine-types#machine_types>`_ machines (16 vCPUs, 60GB memory).

--- a/docs/src/reference/cli/changelog.rst
+++ b/docs/src/reference/cli/changelog.rst
@@ -1,6 +1,14 @@
 CLI Changelog
 =============
 
+21.7.0 (UNRELEASED)
+-------------------
+
+Fixed
+*****
+
+* Fixed bug with ``klio message publish`` not working on ``google-cloud-pubsub > 2.3.0``
+
 .. _cli-21.2.0:
 
 21.2.0 (2021-03-16)

--- a/exec/setup.cfg
+++ b/exec/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 21.7.0.dev1
+current_version = 21.7.0.dev2
 commit = True
 tag = True
 tag_name = exec-{new_version}

--- a/exec/src/klio_exec/__init__.py
+++ b/exec/src/klio_exec/__init__.py
@@ -14,7 +14,7 @@
 #
 
 __author__ = "The klio developers"
-__version__ = "21.7.0.dev1"
+__version__ = "21.7.0.dev2"
 __email__ = "opensource+klio@spotify.com"
 __description__ = "Component of klio project that reduces boilerplate while \
                    writing YAML-config-driven, Dockerized python Beam pipelines\

--- a/lib/setup.cfg
+++ b/lib/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 21.7.0.dev1
+current_version = 21.7.0.dev2
 commit = True
 tag = True
 tag_name = lib-{new_version}

--- a/lib/src/klio/__init__.py
+++ b/lib/src/klio/__init__.py
@@ -14,7 +14,7 @@
 #
 
 __author__ = "The klio developers"
-__version__ = "21.7.0.dev1"
+__version__ = "21.7.0.dev2"
 __email__ = "opensource+klio@spotify.com"
 __description__ = "Conventions for Python + Apache Beam "
 __uri__ = "https://github.com/spotify/klio"


### PR DESCRIPTION
This includes new commits in `develop` since `dev1` (just one that fixes `klio message publish`) and version bumps all packages to `21.7.0.dev2`.

I have included a merge commit instead of manually rebasing `release-21.7.0` because doing that would change the commit sha's of the previous `dev1` version bump commits and subsequently orphan the git tags pointing to them.  If we don't think that's a big deal, rebasing may be cleaner in terms of commit history.

Either way, I haven't pushed git tags for `dev2` yet but will once this PR is merged.


## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ ] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Document any relevant additions/changes in the appropriate spot in `docs/src`.
- [ ] For any change that affects users, update the package's changelog in ``docs/src/reference/<package>/changelog.rst``.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
