### PR TITLE
[lib] Fix pubsub mgr with (1) being stuck in while loop and (2) missing msg extension deadline

### DIFF
--- a/lib/src/klio/message/pubsub_message_manager.py
+++ b/lib/src/klio/message/pubsub_message_manager.py
@@ -82,7 +82,7 @@ class MessageManager:
 
     DEFAULT_DEADLINE_EXTENSION = 30
 
-    def __init__(self, sub_name, heartbeat_sleep=10, manager_sleep=10):
+    def __init__(self, sub_name, heartbeat_sleep=10, manager_sleep=3):
         """Initialize a MessageManager instance.
 
         Args:

--- a/lib/tests/unit/message/test_pubsub_message_manager.py
+++ b/lib/tests/unit/message/test_pubsub_message_manager.py
@@ -171,7 +171,7 @@ def test_msg_manager_heartbeat(mocker, monkeypatch, msg_manager, caplog):
 
     msg_manager.heartbeat(msg)
 
-    assert 1 == len(caplog.records)
+    assert 2 == len(caplog.records)
     mock_time.sleep.assert_called_once_with(msg_manager.heartbeat_sleep)
 
 

--- a/lib/tests/unit/message/test_pubsub_message_manager.py
+++ b/lib/tests/unit/message/test_pubsub_message_manager.py
@@ -111,8 +111,8 @@ def patch_thread_init(mocker, monkeypatch, mock_thread):
 @pytest.mark.parametrize(
     "sleep_args, exp_hb_sleep, exp_mgr_sleep",
     [
-        ({}, 10, 10),
-        ({"heartbeat_sleep": 15}, 15, 10),
+        ({}, 10, 3),
+        ({"heartbeat_sleep": 15}, 15, 3),
         ({"manager_sleep": 15}, 10, 15),
         ({"heartbeat_sleep": 15, "manager_sleep": 15}, 15, 15),
     ],

--- a/lib/tests/unit/message/test_pubsub_message_manager.py
+++ b/lib/tests/unit/message/test_pubsub_message_manager.py
@@ -136,6 +136,23 @@ def test_msg_manager_init(
     assert hb_logger == mm.hrt_logger
 
 
+# This plus the MockTrueFunc class is meant to mock the `foo in my_dict`
+# call, particularly helpful when needing to break out of a `while True` loop.
+# I couldn't otherwise find a way to mock a dictionary to return a different
+# value for the same key lookup.
+def true_once():
+    yield True
+    yield False
+
+
+class MockTrueFunc:
+    def __init__(self):
+        self.gen = true_once()
+
+    def __call__(self, *args, **kwargs):
+        return next(self.gen)
+
+
 def test_msg_manager_manage(mocker, monkeypatch, msg_manager):
     mock_time = mocker.Mock()
     monkeypatch.setattr(pmm, "time", mock_time)
@@ -145,10 +162,11 @@ def test_msg_manager_manage(mocker, monkeypatch, msg_manager):
     mock_rm = mocker.Mock()
     monkeypatch.setattr(msg_manager, "remove", mock_rm)
 
-    msg = mocker.Mock(kmsg_id=1)
-    msg.event = mocker.Mock()
-    msg.event.is_set.side_effect = [False, True]
+    mock_entity_id_to_ack_id = mock.MagicMock()
+    mock_entity_id_to_ack_id.__contains__ = MockTrueFunc()
+    monkeypatch.setattr(pmm, "ENTITY_ID_TO_ACK_ID", mock_entity_id_to_ack_id)
 
+    msg = mocker.Mock(kmsg_id=1)
     msg_manager.manage(msg)
 
     maybe_extend.assert_called_once_with(msg)
@@ -165,10 +183,11 @@ def test_msg_manager_heartbeat(mocker, monkeypatch, msg_manager, caplog):
     mock_rm = mocker.Mock()
     monkeypatch.setattr(msg_manager, "remove", mock_rm)
 
-    msg = mocker.Mock(kmsg_id=1)
-    msg.event = mocker.Mock()
-    msg.event.is_set.side_effect = [False, True]
+    mock_entity_id_to_ack_id = mock.MagicMock()
+    mock_entity_id_to_ack_id.__contains__ = MockTrueFunc()
+    monkeypatch.setattr(pmm, "ENTITY_ID_TO_ACK_ID", mock_entity_id_to_ack_id)
 
+    msg = mocker.Mock(kmsg_id=1)
     msg_manager.heartbeat(msg)
 
     assert 2 == len(caplog.records)
@@ -300,26 +319,21 @@ def test_msg_manager_add(mocker, monkeypatch, msg_manager, caplog):
 def test_msg_manager_remove(mocker, monkeypatch, msg_manager, caplog):
     ack_id, kmsg_id = 1, "2"
     psk_msg1 = pmm.PubSubKlioMessage(ack_id, kmsg_id)
-    monkeypatch.setitem(pmm.ENTITY_ID_TO_ACK_ID, psk_msg1.kmsg_id, psk_msg1)
 
     msg_manager.remove(psk_msg1)
     msg_manager._client.acknowledge.assert_called_once_with(
         msg_manager._sub_name, [ack_id]
     )
-    assert not pmm.ENTITY_ID_TO_ACK_ID.get(kmsg_id)
     assert 1 == len(caplog.records)
-    assert not pmm.ENTITY_ID_TO_ACK_ID.get("2")
 
 
 def test_msg_manager_remove_raises(msg_manager, monkeypatch, caplog):
     ack_id, kmsg_id = 1, "2"
     psk_msg1 = pmm.PubSubKlioMessage(ack_id, kmsg_id)
-    monkeypatch.setitem(pmm.ENTITY_ID_TO_ACK_ID, psk_msg1.kmsg_id, psk_msg1)
 
     msg_manager._client.acknowledge.side_effect = Exception("oh no")
     msg_manager.remove(psk_msg1)
     assert 2 == len(caplog.records)
-    assert not pmm.ENTITY_ID_TO_ACK_ID.get("2")
 
 
 def _generate_kmsg(element):
@@ -333,21 +347,21 @@ def _assert_expected_msg(actual):
     actual_msg.ParseFromString(actual)
 
     expected_msg = klio_pb2.KlioMessage()
-    expected_msg.data.element = b"d34db33f"
+    expected_msg.data.element = b"2"
     assert actual_msg == expected_msg
 
 
 def test_klio_ack_input_msg(mocker, monkeypatch):
-    entity_id = "d34db33f"
-    mock_pklio_msg = mocker.Mock()
-    monkeypatch.setitem(pmm.ENTITY_ID_TO_ACK_ID, entity_id, mock_pklio_msg)
+    ack_id, kmsg_id = 1, "2"
+    psk_msg1 = pmm.PubSubKlioMessage(ack_id, kmsg_id)
+    monkeypatch.setitem(pmm.ENTITY_ID_TO_ACK_ID, psk_msg1.kmsg_id, psk_msg1)
     with beam_test_pipeline.TestPipeline() as p:
         (
             p
-            | beam.Create([entity_id])
+            | beam.Create([kmsg_id])
             | beam.Map(_generate_kmsg)
             | beam.ParDo(helpers.KlioAckInputMessage())
             | beam.Map(_assert_expected_msg)
         )
 
-    mock_pklio_msg.event.set.assert_called_once_with()
+    assert not pmm.ENTITY_ID_TO_ACK_ID.get("2")


### PR DESCRIPTION
This PR contains two fixes/commits for two separate bugs seen while running direct on GKE. For both bugs, this was on python 3.8, apache beam 2.28, and klio* 21.7.0.dev2.

The first commit fixes a bug where the pubsub manager workers get stuck in the `while` loop and can't consume new messages. The behavior we've seen when testing this is that a message would be consumed, processed, and acked, but the heartbeat still continues (as seen with the log line `"Job is still processing <ID>"` every 10 seconds) and no new messages are consumed. How it gets into this state is unknown, but reproducible. This patch is more of a work-around where the heartbeat checks to see if the message is actually still in memory and if not, to ack (just in case) and break out of the loop.

The second commit fixes a bug related to extending the message deadlines. Currently, the pubsub manager consumes the message, and immediately extends the message deadline by 30 seconds (default). It then loops on the message, sleeps for 10 seconds, and checks to see if it should extend the message again (it extends if the last extension happened longer than 24 seconds (30 seconds * 80%)). So the first iteration is +10s since the message was last extended, the second iteration is +20s, and the third iteration is +30s, where it's too late. This caused a _lot_ of duplicate work, especially for the messages that take 30+ seconds to process. The change makes the sleep while looping shorter - to 3 seconds, so it was 1-2 opportunities to extend.

<!--- Describe your changes 

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

<!--- How have you tested this?
Some valid responses are:

* "I have included unit tests" 
* "I have included integration tests"
* "I successfully ran my jobs with this code"

-->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ ] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Document any relevant additions/changes in the appropriate spot in `docs/src`.
- [ ] For any change that affects users, update the package's changelog in ``docs/src/reference/<package>/changelog.rst``.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
