### PR TITLE
[cli] Add safety check for image build vs deploy name for DirectGKERunner

### DIFF
--- a/docs/src/reference/cli/changelog.rst
+++ b/docs/src/reference/cli/changelog.rst
@@ -1,6 +1,14 @@
 CLI Changelog
 =============
 
+21.8.0 (UNRELEASED)
+-------------------
+
+Added
+*****
+
+* Safety check built image vs deployed image differences when deploying with `DirectGKERunner`
+
 21.7.0 (UNRELEASED)
 -------------------
 
@@ -8,6 +16,11 @@ Fixed
 *****
 
 * Fixed bug with ``klio message publish`` not working on ``google-cloud-pubsub > 2.3.0``
+
+Added
+*****
+
+* Support for deploying, stopping, and deleting jobs with `DirectGKERunner`
 
 .. _cli-21.2.0:
 


### PR DESCRIPTION
### Changes
Add a warning message for user if the configured image to be built does not match the image that will be deployed when using DirectOnGKE

Any thoughts on whether we should release everything in a 21.8.0 release or release the things we have already tested thoroughly?

### Testing
- Installed cli and tested running a job with mismatched image
- Added unit test coverage to ensure warning message is seen when images are mismatched


## Checklist for PR author(s)
- [x] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [x] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [x] Document any relevant additions/changes in the appropriate spot in `docs/src`.
- [x] For any change that affects users, update the package's changelog in ``docs/src/reference/<package>/changelog.rst``.


