### PR TITLE
[lib] fix bug in handle_klio decorator with thread-limiting

### DIFF
--- a/integration/batch-modular-default/tests/test_transforms.py
+++ b/integration/batch-modular-default/tests/test_transforms.py
@@ -52,13 +52,6 @@ def expected_log_messages(klio_msg):
         {
             "level": "DEBUG",
             "message": (
-                "KlioThreadLimiter(name=LogKlioMessage.process) Released "
-                "semaphore (available threads:"
-            ),
-        },
-        {
-            "level": "DEBUG",
-            "message": (
                 "[kmsg-received] value: 1 transform: 'LogKlioMessage.process' "
                 "tags: {'metric_type': 'counter'}"
             )
@@ -70,6 +63,13 @@ def expected_log_messages(klio_msg):
         {
             "level": "INFO",
             "message": "Received payload {}".format(klio_msg.data.payload),
+        },
+        {
+            "level": "DEBUG",
+            "message": (
+                "KlioThreadLimiter(name=LogKlioMessage.process) Released "
+                "semaphore (available threads:"
+            ),
         },
         {
             "level": "DEBUG",

--- a/integration/read-bq-write-bq/tests/test_transforms.py
+++ b/integration/read-bq-write-bq/tests/test_transforms.py
@@ -52,13 +52,6 @@ def expected_log_messages(klio_msg):
         {
             "level": "DEBUG",
             "message": (
-                "KlioThreadLimiter(name=LogKlioMessage.process) Released "
-                "semaphore (available threads:"
-            ),
-        },
-        {
-            "level": "DEBUG",
-            "message": (
                 "[kmsg-received] value: 1 transform: 'LogKlioMessage.process' "
                 "tags: {'metric_type': 'counter'}"
             )
@@ -71,6 +64,13 @@ def expected_log_messages(klio_msg):
         {
             "level": "INFO",
             "message": "Received payload {}".format(klio_msg.data.payload),
+        },
+        {
+            "level": "DEBUG",
+            "message": (
+                "KlioThreadLimiter(name=LogKlioMessage.process) Released "
+                "semaphore (available threads:"
+            ),
         },
         {
             "level": "DEBUG",

--- a/integration/read-file-write-file/tests/test_transforms.py
+++ b/integration/read-file-write-file/tests/test_transforms.py
@@ -53,13 +53,6 @@ def expected_log_messages(klio_msg):
         {
             "level": "DEBUG",
             "message": (
-                "KlioThreadLimiter(name=LogKlioMessage.process) Released "
-                "semaphore (available threads:"
-            ),
-        },
-        {
-            "level": "DEBUG",
-            "message": (
                 "[kmsg-received] value: 1 transform: 'LogKlioMessage.process' "
                 "tags: {'metric_type': 'counter'}"
             )
@@ -72,6 +65,13 @@ def expected_log_messages(klio_msg):
         {
             "level": "INFO",
             "message": "Received payload {}".format(klio_msg.data.payload),
+        },
+        {
+            "level": "DEBUG",
+            "message": (
+                "KlioThreadLimiter(name=LogKlioMessage.process) Released "
+                "semaphore (available threads:"
+            ),
         },
         {
             "level": "DEBUG",

--- a/integration/read-file/tests/test_transforms.py
+++ b/integration/read-file/tests/test_transforms.py
@@ -53,13 +53,6 @@ def expected_log_messages(klio_msg):
         {
             "level": "DEBUG",
             "message": (
-                "KlioThreadLimiter(name=LogKlioMessage.process) Released "
-                "semaphore (available threads:"
-            ),
-        },
-        {
-            "level": "DEBUG",
-            "message": (
                 "[kmsg-received] value: 1 transform: 'LogKlioMessage.process' "
                 "tags: {'metric_type': 'counter'}"
             )
@@ -72,6 +65,13 @@ def expected_log_messages(klio_msg):
         {
             "level": "INFO",
             "message": "Received payload {}".format(klio_msg.data.payload),
+        },
+        {
+            "level": "DEBUG",
+            "message": (
+                "KlioThreadLimiter(name=LogKlioMessage.process) Released "
+                "semaphore (available threads:"
+            ),
         },
         {
             "level": "DEBUG",

--- a/lib/tests/unit/transforms/test_decorators.py
+++ b/lib/tests/unit/transforms/test_decorators.py
@@ -188,6 +188,87 @@ def test_thread_limiting(
     mock_semaphore.return_value.release.assert_called_once_with()
 
 
+@pytest.mark.parametrize(
+    "max_thread_count,patch_str",
+    (
+        (None, "threading.BoundedSemaphore"),
+        (_thread_limiter.ThreadLimit.DEFAULT, "threading.BoundedSemaphore"),
+        (_thread_limiter.ThreadLimit.NONE, "_DummySemaphore"),
+    ),
+)
+def test_thread_limiting_process_method(
+    max_thread_count, patch_str, kmsg, mock_config, mocker, monkeypatch
+):
+    mock_function = mocker.Mock()
+    mock_semaphore = mocker.Mock()
+    monkeypatch.setattr(
+        f"klio.utils._thread_limiter.{patch_str}", mock_semaphore
+    )
+
+    kwargs = {}
+    if max_thread_count is not None:
+        kwargs["max_thread_count"] = max_thread_count
+
+    class TestDoFn(beam.DoFn):
+        @decorators._handle_klio(**kwargs)
+        def process(self, msg_data):
+            mock_semaphore.return_value.acquire.assert_called_once_with()
+            mock_semaphore.return_value.release.assert_not_called()
+            mock_function()
+            return msg_data
+
+    dofn = TestDoFn()
+
+    # notice - process is always a generator, even when `return` is used
+    gen = dofn.process(kmsg.SerializeToString())
+
+    # need to pull everything from the generator
+    [z for z in gen]
+
+    assert 1 == mock_function.call_count
+    mock_semaphore.return_value.acquire.assert_called_once_with()
+    mock_semaphore.return_value.release.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    "max_thread_count,patch_str",
+    (
+        (None, "threading.BoundedSemaphore"),
+        (_thread_limiter.ThreadLimit.DEFAULT, "threading.BoundedSemaphore"),
+        (_thread_limiter.ThreadLimit.NONE, "_DummySemaphore"),
+    ),
+)
+def test_thread_limiting_nonprocess_method(
+    max_thread_count, patch_str, kmsg, mock_config, mocker, monkeypatch
+):
+    # Unlike the `process` method, non-process method should be treated as a
+    # regular function
+    mock_function = mocker.Mock()
+    mock_semaphore = mocker.Mock()
+    monkeypatch.setattr(
+        f"klio.utils._thread_limiter.{patch_str}", mock_semaphore
+    )
+
+    kwargs = {}
+    if max_thread_count is not None:
+        kwargs["max_thread_count"] = max_thread_count
+
+    class TestMethod(object):
+        @decorators._handle_klio(**kwargs)
+        def other_method(self, msg_data):
+            mock_semaphore.return_value.acquire.assert_called_once_with()
+            mock_semaphore.return_value.release.assert_not_called()
+            mock_function()
+            return msg_data
+
+    dofn = TestMethod()
+    dofn.other_method(kmsg.SerializeToString())
+
+    assert 1 == mock_function.call_count
+    mock_semaphore.return_value.acquire.assert_called_once_with()
+    mock_semaphore.return_value.release.assert_called_once_with()
+
+
 def test_thread_limiting_custom_limiter(
     kmsg, mock_config, mocker, monkeypatch
 ):
@@ -408,3 +489,51 @@ def test_serialize_klio_metrics(mock_config, kmsg):
     assert len(pcoll) == msg_timer.committed.count
     assert "simple_map" == msg_timer.key.metric.namespace
     assert "kmsg-timer" == msg_timer.key.metric.name
+
+
+@pytest.mark.parametrize(
+    "items",
+    ([], [1], [1, 2], [1, 2, 3], [Exception("Hey")], [1, Exception("HEY")]),
+)
+def test_threadlimitgenerator(mocker, items):
+    def test_gen(items):
+        for item in items:
+            if isinstance(item, Exception):
+                raise item
+            yield item
+
+    limiter = mocker.Mock()
+
+    gen = decorators.ThreadLimitGenerator(limiter, test_gen(items))
+
+    limiter.acquire.assert_called_once_with()
+    limiter.release.assert_not_called()
+    for item in items:
+        if isinstance(item, Exception):
+            with pytest.raises(Exception):
+                next(gen)
+            limiter.release.assert_called_once_with()
+            break
+        else:
+            next(gen)
+            limiter.release.assert_not_called()
+
+    with pytest.raises(StopIteration):
+        next(gen)
+
+    limiter.release.assert_called_once_with()
+
+
+def test_threadlimitgenerator_del_release(mocker):
+    # This test verifies the __del__ method properly releases the semaphore
+
+    limiter = mocker.Mock()
+
+    def subfunc():
+        _ = decorators.ThreadLimitGenerator(limiter, iter([1, 2]))
+
+        limiter.acquire.assert_called_once_with()
+        limiter.release.assert_not_called()
+
+    subfunc()
+    limiter.release.assert_called_once_with()


### PR DESCRIPTION
This fixes a bug with the `ThreadLimiter`  not properly wrapping user code in `DoFn` `process` methods.

Basically the current behavior is the thread limiter will acquire and release the lock before execution enters the `process` method, resulting in effectively no actual thread limiting around user code.  This happens because:

1.  in the `handle_klio` decorator, the thread limiter is used as a context manager
2. The `process` method always returns a generator.  This is regardless of whether the user code uses `return` or `yield`.
3. The decorator ends up returning the generator, and the generator is actually not invoked until some future point in execution, outside the context of the thread-limiter.  So the thread limiter correctly acquires the lock, but the lock is only held when building the generator to return, and is released before the any user code is actually executed.

This behavior can be clearly seen when logging is turned on:

```
DEBUG:klio.concurrency:KlioThreadLimiter(name=HelloKlio.process) Blocked – waiting on semaphore for an available thread (available threads: 1)
DEBUG:klio.concurrency:KlioThreadLimiter(name=HelloKlio.process) Released semaphore (available threads: 1)
INFO:klio:Log message from process method
```

I tested this extensively on direct runner and Dataflow.  Especially on Dataflow it is clear that before the fix, multiple message area processed concurrently even with `max_thread_count=1`, but after the fix only one message is processed at a time.



## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ ] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Document any relevant additions/changes in the appropriate spot in `docs/src`.
- [ ] For any change that affects users, update the package's changelog in ``docs/src/reference/<package>/changelog.rst``.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
