### PR TITLE
[cli] Add k8s labels to deployments

### DIFF
--- a/integration/audio-spectrograms/job-requirements.in
+++ b/integration/audio-spectrograms/job-requirements.in
@@ -1,4 +1,6 @@
 apache-beam[gcp]==2.28.0
 librosa
 pytest
+# see https://github.com/spotify/klio/pull/210#issuecomment-898969607
+matplotlib --only-binary matplotlib
 # Note: klio packages are installed via docker


### PR DESCRIPTION
This ensures required and best-practices labels are set (which is particularly helpful for cost association), as well as any labels defined in the klio job config. This also adds a "deployed by" label and a "klio cli version" label, which can be particularly helpful during debugging (we currently have this for our Dataflow runner).

Since this code is not run inside the job's docker container, I wasn't able to get other klio package versions. While users can install mis-matching packages, hopefully with the recent change to calendar versioning + releasing-all-packages-per-release approach will minimize that. If worse comes to worst, we can add code to run something like `pip freeze | grep klio` in the job's container.

<!--- Describe your changes 

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

<!--- How have you tested this?
Some valid responses are:

* "I have included unit tests" 
* "I have included integration tests"
* "I successfully ran my jobs with this code"

-->

* I have included unit tests
* Instead of running a job, I dumped the resulting final `deployment.yaml` into a temp file with various initial `deployment.yaml` setups.
 
## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [x] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [x] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [x] Document any relevant additions/changes in the appropriate spot in `docs/src`.
- [x] For any change that affects users, update the package's changelog in ``docs/src/reference/<package>/changelog.rst``.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
