### PR TITLE
[cli] Respect all k8s yaml when deploying to DirectOnGKE

### DIFF
--- a/cli/setup.cfg
+++ b/cli/setup.cfg
@@ -5,7 +5,7 @@ commit = True
 tag = True
 message = [cli] Bump version: {current_version} → {new_version}
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
-serialize = 
+serialize =
 	{major}.{minor}.{patch}
 
 [bumpversion:file:src/klio_cli/__init__.py]

--- a/cli/src/klio_cli/commands/job/gke.py
+++ b/cli/src/klio_cli/commands/job/gke.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+import glob
 import logging
 import os
 import re
@@ -21,6 +22,7 @@ import glom
 import yaml
 from kubernetes import client as k8s_client
 from kubernetes import config as k8s_config
+from kubernetes.dynamic.client import DynamicClient
 
 from klio_cli import __version__ as klio_cli_version
 from klio_cli.commands import base
@@ -52,64 +54,79 @@ class GKECommandMixin(object):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._deployment_config = None
-        self._kubernetes_client = None
+        self._dynamic_client = None
         self._kubernetes_active_context = None
 
     @property
-    def kubernetes_client(self):
-        if not self._kubernetes_client:
+    def kubernetes_active_context(self):
+        if not self._kubernetes_active_context:
             # TODO: This grabs configs from '~/.kube/config'. @shireenk
             #  We should add a check that this file exists
             # If it does not exist then we should create configurations.
             # See link:
             # https://github.com/kubernetes-client/python-base/blob/master/config/kube_config.py#L825
             k8s_config.load_kube_config()
-            self._kubernetes_client = k8s_client.AppsV1Api()
-
-        return self._kubernetes_client
-
-    @property
-    def kubernetes_active_context(self):
-        if not self._kubernetes_active_context:
             _, active_context = k8s_config.list_kube_config_contexts()
             self._kubernetes_active_context = active_context
 
         return self._kubernetes_active_context
 
     @property
-    def deployment_config(self):
-        if not self._deployment_config:
-            path_to_deployment_config = os.path.join(
-                self.job_dir, "kubernetes", "deployment.yaml"
-            )
-            with open(path_to_deployment_config) as f:
-                self._deployment_config = yaml.safe_load(f)
-        return self._deployment_config
+    def dynamic_client(self):
+        if not self._dynamic_client:
+            k8s_config.load_kube_config()
+            with k8s_client.ApiClient() as api_client:
+                dyn_client = DynamicClient(api_client)
+                self._dynamic_client = dyn_client
+        return self._dynamic_client
 
-    def _deployment_exists(self):
+    def get_deployment_config(self, config_dir="kubernetes"):
+        """Searches kubernetes directory for a Deployment
+            configuration type.
+
+        Returns:
+            dict: deployment_config loaded from a yaml file
+        """
+        k8s_yamls = glob.glob(os.path.join(config_dir, "*.yaml"))
+        # Find the deployment
+        for resource_file in k8s_yamls:
+            with open(os.path.join(resource_file)) as d:
+                yaml_config = yaml.safe_load(d)
+                if yaml_config["kind"] == "Deployment":
+                    return yaml_config
+
+    def _resource_exists(self, resource_config):
         """Check to see if a deployment already exists
-
+        Args:
+            resource_config (dict): Kubernetes resource config
+                read in from yaml file.
         Returns:
             bool: Whether a deployment for the given name-namespace
                 combination exists
         """
-        dep = self.deployment_config
-        namespace = glom.glom(dep, "metadata.namespace")
-        deployment_name = glom.glom(dep, "metadata.name")
-        resp = self.kubernetes_client.list_namespaced_deployment(
-            namespace=namespace,
+        api_version = glom.glom(resource_config, "apiVersion")
+        kind = glom.glom(resource_config, "kind")
+        name = glom.glom(resource_config, "metadata.name")
+        namespace = glom.glom(resource_config, "metadata.namespace")
+        api_instance = self.dynamic_client.resources.get(
+            api_version=api_version, kind=kind
         )
+        resp = api_instance.get(body=resource_config, namespace=namespace)
         for i in resp.items:
-            if i.metadata.name == deployment_name:
+            if i.metadata.name == name:
                 return True
         return False
 
-    def _update_deployment(self, replica_count=None, image_tag=None):
+    def _edit_deployment(
+        self, deployment_config, replica_count=None, image_tag=None
+    ):
         """This will update a deployment with a provided
-            replica count or image tag
+            replica count or image tag. This mutates the
+            deployment_config object
 
         Args:
+            deployment_config(dict): deployment configuration dict
+                that will get mutated with updated fields
             replica_count (int): Number of replicas the
                 deployment will be updated with.
                 If not provided then this will not be changed
@@ -117,45 +134,34 @@ class GKECommandMixin(object):
                 to the updated deployment.
                 If not provided then this will not be updated.
         """
-        deployment_name = glom.glom(self.deployment_config, "metadata.name")
-        namespace = glom.glom(self.deployment_config, "metadata.namespace")
         log_messages = []
         if replica_count is not None:
-            glom.assign(
-                self._deployment_config, "spec.replicas", replica_count
-            )
+            glom.assign(deployment_config, "spec.replicas", replica_count)
             log_messages.append(f"Scaled deployment to {replica_count}")
         if image_tag:
             image_path = "spec.template.spec.containers.0.image"
-            image_base = glom.glom(self._deployment_config, image_path)
+            image_base = glom.glom(deployment_config, image_path)
             # Strip off existing image tag if present
             image_base = re.split(":", image_base)[0]
             full_image = image_base + f":{image_tag}"
-            glom.assign(self._deployment_config, image_path, full_image)
+            glom.assign(deployment_config, image_path, full_image)
             log_messages.append(
                 f"Update deployment with image tag {image_tag}"
             )
-        resp = self.kubernetes_client.patch_namespaced_deployment(
-            name=deployment_name,
-            namespace=namespace,
-            body=self.deployment_config,
-        )
-        log_messages.append(f"Update deployment with {resp.metadata.name}")
         for message in log_messages:
             logging.info(message)
 
-        ui_link = self._build_ui_link_from_current_context()
+        ui_link = self._build_ui_link_from_current_context(deployment_config)
         logging.info(f"Deployment details: {ui_link}")
 
-    def _build_ui_link_from_current_context(self):
+    def _build_ui_link_from_current_context(self, deployment_config):
         context_name = self.kubernetes_active_context["name"]
         # context seems to follow the format
         # gke_{project}_{region}_{clustername}
         _, gke_project, region, current_cluster = context_name.split("_")
 
-        dep = self.deployment_config
-        namespace = glom.glom(dep, "metadata.namespace")
-        deployment_name = glom.glom(dep, "metadata.name")
+        namespace = glom.glom(deployment_config, "metadata.namespace")
+        deployment_name = glom.glom(deployment_config, "metadata.name")
         link = GKECommandMixin.GKE_UI_LINK_FORMAT.format(
             region=region,
             cluster=current_cluster,
@@ -165,6 +171,21 @@ class GKECommandMixin(object):
         )
         return link
 
+    def _update_resource(self, resource_config):
+        api_version = resource_config["apiVersion"]
+        kind = resource_config["kind"]
+        resource_name = glom.glom(resource_config, "metadata.name")
+        namespace = glom.glom(resource_config, "metadata.namespace")
+
+        api_instance = self.dynamic_client.resources.get(
+            api_version=api_version, kind=kind
+        )
+
+        api_instance.patch(
+            name=resource_name, namespace=namespace, body=resource_config,
+        )
+        logging.info(f"Updated {kind} {resource_name}")
+
 
 class RunPipelineGKE(GKECommandMixin, base.BaseDockerizedPipeline):
     def __init__(
@@ -173,22 +194,38 @@ class RunPipelineGKE(GKECommandMixin, base.BaseDockerizedPipeline):
         super().__init__(job_dir, klio_config, docker_runtime_config)
         self.run_job_config = run_job_config
 
-    def _apply_image_to_deployment_config(self):
+    def _apply_all_resources(self, config_dir="kubernetes"):
+        k8s_yamls = glob.glob(os.path.join(config_dir, "*.yaml"))
+        if not len(k8s_yamls) > 0:
+            logging.warning(
+                f"No '*.yaml' files located in the {config_dir} directory. "
+                "No resources will be created."
+            )
+            return
+
+        for resource_file in k8s_yamls:
+            with open(os.path.join(resource_file)) as d:
+                resource_config = yaml.safe_load(d)
+            if resource_config["kind"] == "Deployment":
+                self._apply_labels_to_deployment_config(resource_config)
+                self._apply_image_to_deployment_config(resource_config)
+            self._apply_resource(resource_config)
+
+    def _apply_image_to_deployment_config(self, deployment_config):
         image_tag = self.docker_runtime_config.image_tag
         pipeline_options = self.klio_config.pipeline_options
         if image_tag:
-            dep = self.deployment_config
             image_path = "spec.template.spec.containers.0.image"
             # TODO: If more than one image deployed,
             #  we need to search for correct container
-            image_base = glom.glom(dep, image_path)
+            image_base = glom.glom(deployment_config, image_path)
             # Strip off existing image tag if any
             image_base = re.split(":", image_base)[0]
             full_image = f"{image_base}:{image_tag}"
-            glom.assign(self._deployment_config, image_path, full_image)
+            glom.assign(deployment_config, image_path, full_image)
         # Check to see if the kubernetes image to be deployed is the same
         # image that is built
-        k8s_image = glom.glom(self.deployment_config, image_path)
+        k8s_image = glom.glom(deployment_config, image_path)
         built_image_base = pipeline_options.worker_harness_container_image
         built_image = f"{built_image_base}:{image_tag}"
         if built_image != k8s_image:
@@ -259,7 +296,7 @@ class RunPipelineGKE(GKECommandMixin, base.BaseDockerizedPipeline):
                     f"See {help_url} for valid values."
                 )
 
-    def _apply_labels_to_deployment_config(self):
+    def _apply_labels_to_deployment_config(self, deployment_config):
         # `metadata.labels` are a best practices thing, but not required
         # (these would be "deployment labels"). At least one label defined in
         # `spec.template.metadata.labels` is required for k8s deployments
@@ -272,7 +309,7 @@ class RunPipelineGKE(GKECommandMixin, base.BaseDockerizedPipeline):
 
         # standard practice labels ("app" and "role")
         existing_metadata_labels = glom.glom(
-            self.deployment_config, "metadata.labels", default={}
+            deployment_config, "metadata.labels", default={}
         )
         metadata_app = glom.glom(existing_metadata_labels, "app", default=None)
         if not metadata_app:
@@ -281,7 +318,7 @@ class RunPipelineGKE(GKECommandMixin, base.BaseDockerizedPipeline):
         metadata_labels.update(existing_metadata_labels)
 
         existing_pod_labels = glom.glom(
-            self.deployment_config, "spec.template.metadata.labels", default={}
+            deployment_config, "spec.template.metadata.labels", default={}
         )
         pod_app = glom.glom(existing_pod_labels, "app", default=None)
         pod_role = glom.glom(existing_pod_labels, "role", default=None)
@@ -295,7 +332,7 @@ class RunPipelineGKE(GKECommandMixin, base.BaseDockerizedPipeline):
         pod_labels.update(existing_pod_labels)
 
         existing_selector_labels = glom.glom(
-            self.deployment_config, "spec.selector.matchLabels", default={}
+            deployment_config, "spec.selector.matchLabels", default={}
         )
         selector_app = glom.glom(existing_selector_labels, "app", default=None)
         selector_role = glom.glom(
@@ -346,42 +383,46 @@ class RunPipelineGKE(GKECommandMixin, base.BaseDockerizedPipeline):
             # raises if not valid
             RunPipelineGKE._validate_labels(label_path, label_dict)
             glom.assign(
-                self.deployment_config, label_path, label_dict, missing=dict
+                deployment_config, label_path, label_dict, missing=dict
             )
 
-    def _apply_deployment(self):
-        """Create a namespaced deploy if the deployment does not already exist.
-        If the namespaced deployment already exists then
+    def _apply_resource(self, resource_config):
+        """Create a namespaced resource if the resource does not already exist.
+        If the namespaced resource already exists then
         `self.run_job_config.update` will determine if the
-        deployment will be updated or not.
+        resource will be updated or not.
         """
-        dep = self.deployment_config
-        namespace = glom.glom(dep, "metadata.namespace")
-        deployment_name = glom.glom(dep, "metadata.name")
-        if not self._deployment_exists():
-            resp = self.kubernetes_client.create_namespaced_deployment(
-                body=dep, namespace=namespace
-            )
-            deployment_name = resp.metadata.name
-            current_cluster = self.kubernetes_active_context["name"]
-            ui_link = self._build_ui_link_from_current_context()
-            logging.info(
-                f"Deployment created for {deployment_name} "
-                f"in cluster {current_cluster}. "
-                f"Deployment details: {ui_link}"
-            )
-        else:
+        api_version = resource_config["apiVersion"]
+        kind = resource_config["kind"]
+        resource_name = glom.glom(resource_config, "metadata.name")
+        namespace = glom.glom(resource_config, "metadata.namespace")
+
+        if self._resource_exists(resource_config):
             if self.run_job_config.update:
-                self._update_deployment()
+                self._update_resource(resource_config)
             else:
                 logging.warning(
-                    f"Cannot apply deployment for {deployment_name}. "
-                    "To update an existing deployment, run "
+                    f"Cannot apply {kind} for {resource_name}. "
+                    "To update an existing resource, run "
                     "`klio job run --update`, or set `pipeline_options.update`"
                     " to `True` in the job's`klio-job.yaml` file. "
                     "Run `klio job stop` to scale a deployment down to 0. "
                     "Run `klio job delete` to delete a deployment entirely."
                 )
+                return
+        else:
+            api_instance = self.dynamic_client.resources.get(
+                api_version=api_version, kind=kind
+            )
+
+            api_instance.create(
+                namespace=namespace, body=resource_config,
+            )
+            current_cluster = self.kubernetes_active_context["name"]
+            logging.info(
+                f"Created {kind} {resource_name} "
+                f"in cluster {current_cluster}."
+            )
 
     def _setup_docker_image(self):
         super()._setup_docker_image()
@@ -402,10 +443,7 @@ class RunPipelineGKE(GKECommandMixin, base.BaseDockerizedPipeline):
         self._check_docker_setup()
         self._setup_docker_image()
 
-        self._apply_image_to_deployment_config()
-        self._apply_labels_to_deployment_config()
-
-        self._apply_deployment(**kwargs)
+        self._apply_all_resources(**kwargs)
 
 
 class StopPipelineGKE(GKECommandMixin):
@@ -414,10 +452,12 @@ class StopPipelineGKE(GKECommandMixin):
         self.job_dir = job_dir
 
     def stop(self):
-        """Delete a namespaced deployment
+        """Scale a namespaced deployment down to 0 replicas
         Expects existence of a kubernetes/deployment.yaml
         """
-        self._update_deployment(replica_count=0)
+        deployment = self.get_deployment_config()
+        self._edit_deployment(deployment, replica_count=0)
+        self._update_resource(deployment)
 
 
 class DeletePipelineGKE(GKECommandMixin):
@@ -425,29 +465,39 @@ class DeletePipelineGKE(GKECommandMixin):
         super().__init__()
         self.job_dir = job_dir
 
-    def _delete_deployment(self):
-        dep = self.deployment_config
-        deployment_name = glom.glom(dep, "metadata.name")
-        namespace = glom.glom(dep, "metadata.namespace")
-        # Some messaging might change if we multi-cluster deployments
-        current_cluster = self.kubernetes_active_context["name"]
-        if self._deployment_exists():
-            resp = self.kubernetes_client.delete_namespaced_deployment(
-                name=deployment_name,
+    def _delete_all_resources(self, config_dir="kubernetes"):
+        k8s_yamls = glob.glob(os.path.join(config_dir, "*.yaml"))
+        for resource_file in k8s_yamls:
+            with open(os.path.join(resource_file)) as d:
+                yaml_config = yaml.safe_load(d)
+            self._delete_resource(yaml_config)
+
+    def _delete_resource(self, resource_config):
+        api_version = resource_config["apiVersion"]
+        kind = resource_config["kind"]
+        resource_name = glom.glom(resource_config, "metadata.name")
+        namespace = glom.glom(resource_config, "metadata.namespace")
+
+        if self._resource_exists(resource_config):
+            api_instance = self.dynamic_client.resources.get(
+                api_version=api_version, kind=kind
+            )
+            api_instance.delete(
+                name=resource_name,
                 namespace=namespace,
                 body=k8s_client.V1DeleteOptions(
                     propagation_policy="Foreground", grace_period_seconds=5
                 ),
             )
-            logging.info(f"Deployment deleted: {resp}.")
-        else:
-            logging.error(
-                f"Deployment {namespace}:{deployment_name} "
-                f"does not exist in cluster {current_cluster}."
+            current_cluster = self.kubernetes_active_context["name"]
+            logging.info(
+                f"Deleted {kind} {resource_name} "
+                f"in cluster {current_cluster}."
             )
+        else:
+            logging.warning(f"{kind} {resource_name} does not exists.")
 
     def delete(self):
-        """Delete a namespaced deployment
-        Expects existence of a kubernetes/deployment.yaml
+        """Delete a namespaced resource
         """
-        self._delete_deployment()
+        self._delete_all_resources()

--- a/cli/tests/commands/job/kubernetes/test_deployment.yaml
+++ b/cli/tests/commands/job/kubernetes/test_deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: gke-baseline-random-music
+  name: gke-baseline-random-music
+  namespace: sigint
+spec:
+  replicas: 100
+  selector:
+    matchLabels:
+      app: gke-baseline-random-music
+      role: gkebaselinerandommusic
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: gke-baseline-random-music
+        role: gkebaselinerandommusic
+    spec:
+      containers:
+      - env:
+        - name: MY_CREDENTIALS
+          value: /my_key.json
+        image: gcr.io/sigint/gke-baseline-random-music-gke
+        name: gke-baseline-random-music
+        resources:
+          limits:
+            cpu: 8
+            memory: 20G
+          requests:
+            cpu: 4
+            memory: 16G
+        volumeMounts:
+        - mountPath: /var/secrets/google
+          name: google-cloud-key

--- a/cli/tests/commands/job/kubernetes/test_hpa.yaml
+++ b/cli/tests/commands/job/kubernetes/test_hpa.yaml
@@ -1,0 +1,22 @@
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: gke-baseline-random-music
+  namespace: sigint
+  labels:
+    app: gke-baseline-random-music
+    role: gkebaselinerandommusic
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: gke-baseline-random-music
+  minReplicas: 1
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: AverageValue
+          averageValue: 1G

--- a/cli/tests/commands/job/test_gke.py
+++ b/cli/tests/commands/job/test_gke.py
@@ -13,8 +13,11 @@
 # limitations under the License.
 #
 
+import os
+
 import glom
 import pytest
+import yaml
 
 from kubernetes import client as k8s_client
 
@@ -22,6 +25,10 @@ from klio_core import config
 
 from klio_cli import cli
 from klio_cli.commands.job import gke as job_gke
+
+
+HERE = os.path.abspath(os.path.join(os.path.abspath(__file__), os.path.pardir))
+TEST_K8S_DIRECTORY = os.path.join(HERE, "kubernetes")
 
 
 @pytest.fixture
@@ -90,6 +97,7 @@ def mock_docker_client(mocker):
 
 @pytest.fixture
 def run_pipeline_gke(
+    mocker,
     klio_config,
     docker_runtime_config,
     run_job_config,
@@ -110,72 +118,17 @@ def run_pipeline_gke(
 
 
 @pytest.fixture
+def hpa_config():
+    with open(os.path.join(TEST_K8S_DIRECTORY, "test_hpa.yaml")) as h:
+        hpa_config = yaml.safe_load(h)
+        return hpa_config
+
+
+@pytest.fixture
 def deployment_config():
-    return {
-        "apiVersion": "apps/v1",
-        "kind": "Deployment",
-        "metadata": {
-            "name": "gke-baseline-random-music",
-            "namespace": "sigint",
-            "labels": {"app": "gke-baseline-random-music"},
-        },
-        "spec": {
-            "replicas": 100,
-            "strategy": {"type": "Recreate"},
-            "selector": {
-                "matchLabels": {
-                    "app": "gke-baseline-random-music",
-                    "role": "gkebaselinerandommusic",
-                }
-            },
-            "template": {
-                "metadata": {
-                    "labels": {
-                        "app": "gke-baseline-random-music",
-                        "role": "gkebaselinerandommusic",
-                    },
-                    "annotations": {
-                        "podpreset.admission.spotify.com/exclude": (
-                            "container/" "ffwd-java-shim, environment/ffwd"
-                        )
-                    },
-                },
-                "spec": {
-                    "volumes": [
-                        {
-                            "name": "google-cloud-key",
-                            "secret": {"secretName": "lynn-podcast-key"},
-                        }
-                    ],
-                    "containers": [
-                        {
-                            "name": "gke-baseline-random-music",
-                            "image": (
-                                "gcr.io/sigint/gke-base"
-                                "line-random-music-gke"
-                            ),
-                            "resources": {
-                                "requests": {"cpu": 4, "memory": "16G"},
-                                "limits": {"cpu": 8, "memory": "20G"},
-                            },
-                            "volumeMounts": [
-                                {
-                                    "name": "google-cloud-key",
-                                    "mountPath": "/var/secrets/google",
-                                }
-                            ],
-                            "env": [
-                                {
-                                    "name": "GOOGLE_APPLICATION_CREDENTIALS",
-                                    "value": "/var/secrets/google/key.json",
-                                }
-                            ],
-                        }
-                    ],
-                },
-            },
-        },
-    }
+    with open(os.path.join(TEST_K8S_DIRECTORY, "test_deployment.yaml")) as d:
+        deployment_config = yaml.safe_load(d)
+    return deployment_config
 
 
 @pytest.fixture
@@ -199,8 +152,7 @@ def deployment_resp(deployment_config):
     )
     template = k8s_client.V1PodTemplateSpec(
         metadata=k8s_client.V1ObjectMeta(
-            labels=container_spec_config["labels"],
-            annotations=container_spec_config["annotations"],
+            labels=container_spec_config["labels"], annotations=[],
         ),
         spec=k8s_client.V1PodSpec(containers=[container]),
     )
@@ -227,17 +179,21 @@ def deployment_resp(deployment_config):
 
 
 @pytest.fixture
-def deployment_response_list(deployment_config, deployment_resp):
-    resp = k8s_client.models.v1_deployment_list.V1DeploymentList(
-        items=[deployment_resp]
-    )
-    return resp
+def mock_api_instance(mocker, deployment_config, deployment_resp):
+    mock_api_instance = mocker.Mock()
+    mock_instance_response = mocker.Mock()
+    mock_instance_response.items = [deployment_resp]
+    mock_api_instance.get.return_value = mock_instance_response
+    mock_api_instance.create.return_value = mock_instance_response
+    mock_api_instance.patch.return_value = mock_instance_response
+    mock_api_instance.delete.return_value = mock_instance_response
+    return mock_api_instance
 
 
 @pytest.fixture
-def deployment_response_list_not_exist():
-    resp = k8s_client.models.v1_deployment_list.V1DeploymentList(items=[])
-    return resp
+def dynamic_client(mocker, mock_api_instance):
+    mock_client = mocker.Mock()
+    return mock_client
 
 
 @pytest.fixture
@@ -252,72 +208,61 @@ def active_context():
     }
 
 
-def test_update_deployment(
-    deployment_config,
+def test_update_resource(
     run_pipeline_gke,
-    deployment_resp,
+    dynamic_client,
+    mock_api_instance,
+    deployment_config,
     active_context,
     monkeypatch,
     mocker,
 ):
     deployment_name = glom.glom(deployment_config, "metadata.name")
     namespace = glom.glom(deployment_config, "metadata.namespace")
-    mock_k8s_client = mocker.Mock()
-    mock_k8s_client.patch_namespaced_deployment.return_value = deployment_resp
+    dynamic_client.resources.get.return_value = mock_api_instance
 
-    monkeypatch.setattr(
-        run_pipeline_gke, "_kubernetes_client", mock_k8s_client
-    )
     monkeypatch.setattr(
         run_pipeline_gke, "_kubernetes_active_context", active_context
     )
-    monkeypatch.setattr(
-        run_pipeline_gke, "_deployment_config", deployment_config
-    )
+    monkeypatch.setattr(run_pipeline_gke, "_dynamic_client", dynamic_client)
 
-    run_pipeline_gke._update_deployment()
-    mock_k8s_client.patch_namespaced_deployment.assert_called_once_with(
+    run_pipeline_gke._update_resource(deployment_config)
+    mock_api_instance.patch.assert_called_once_with(
         name=deployment_name, namespace=namespace, body=deployment_config,
     )
 
 
 # Tests for internal functions
 @pytest.mark.parametrize(
-    "deployed,is_exists",
-    (
-        (["deployment-1", "gke-baseline-random-music"], True),
-        (["deployment-2"], False),
-    ),
+    "is_exists", (True, False),
 )
-def test_deployment_exists(
+def test_resource_exists(
     deployment_resp,
     deployment_config,
+    mock_api_instance,
+    dynamic_client,
     active_context,
     run_pipeline_gke,
-    deployment_response_list,
     monkeypatch,
     mocker,
-    deployed,
     is_exists,
 ):
-    mock_k8s_client = mocker.Mock()
-    mock_k8s_client.patch_namespaced_deployment.return_value = deployment_resp
-    mock_k8s_client.list_namespaced_deployment.return_value = (
-        deployment_response_list
-    )
-    monkeypatch.setattr(
-        run_pipeline_gke, "_kubernetes_client", mock_k8s_client
-    )
+    if not is_exists:
+        mock_instance_response = mocker.Mock()
+        mock_instance_response.items = []
+        mock_api_instance.get.return_value = mock_instance_response
+
+    dynamic_client.resources.get.return_value = mock_api_instance
     monkeypatch.setattr(
         run_pipeline_gke, "_kubernetes_active_context", active_context
     )
-    monkeypatch.setattr(
-        run_pipeline_gke, "_deployment_config", deployment_config
+    monkeypatch.setattr(run_pipeline_gke, "_dynamic_client", dynamic_client)
+    existence = run_pipeline_gke._resource_exists(deployment_config)
+    mock_api_instance.get.assert_called_once_with(
+        body=deployment_config,
+        namespace=glom.glom(deployment_config, "metadata.namespace"),
     )
-    run_pipeline_gke._deployment_exists()
-    mock_k8s_client.list_namespaced_deployment.assert_called_once_with(
-        namespace=glom.glom(deployment_config, "metadata.namespace")
-    )
+    assert existence == is_exists
 
 
 @pytest.mark.parametrize(
@@ -419,14 +364,18 @@ def test_validate_labels_raises(label_dict):
     "is_ci,exp_deployed_by", (("true", "ci"), ("false", "stub-user"))
 )
 def test_apply_labels_to_deployment_config(
-    input_config, is_ci, exp_deployed_by, run_pipeline_gke, monkeypatch
+    input_config,
+    is_ci,
+    exp_deployed_by,
+    run_pipeline_gke,
+    monkeypatch,
+    deployment_config,
 ):
     monkeypatch.setitem(job_gke.os.environ, "USER", "stub-user")
     monkeypatch.setitem(job_gke.os.environ, "CI", is_ci)
     monkeypatch.setattr(job_gke, "klio_cli_version", "stub-version")
 
     # TODO: patch user config for user labels
-    monkeypatch.setattr(run_pipeline_gke, "_deployment_config", input_config)
     user_labels = [
         "label_a=value_a",
         "label-b=value-b",
@@ -436,74 +385,47 @@ def test_apply_labels_to_deployment_config(
     monkeypatch.setattr(
         run_pipeline_gke.klio_config.pipeline_options, "labels", user_labels
     )
-
-    expected_config = {
-        "metadata": {"name": "test-job", "labels": {"app": "test-job"}},
-        "spec": {
-            "template": {
-                "metadata": {
-                    "labels": {
-                        "app": "test-job",
-                        "role": "testjob",
-                        "klio/deployed_by": exp_deployed_by,
-                        "klio/klio_cli_version": "stub-version",
-                        "label_a": "value_a",
-                        "label-b": "value-b",
-                        "label-c": "",
-                    }
-                },
-            },
-            "selector": {
-                "matchLabels": {"app": "test-job", "role": "testjob"}
-            },
-        },
+    labels = {
+        "app": "test-job",
+        "role": "testjob",
+        "klio/deployed_by": exp_deployed_by,
+        "klio/klio_cli_version": "stub-version",
+        "label_a": "value_a",
+        "label-b": "value-b",
+        "label-c": "",
     }
+    expected_config = deployment_config.copy()
+    glom.assign(expected_config, "spec.template.metadata.labels", labels)
 
-    run_pipeline_gke._apply_labels_to_deployment_config()
-    assert expected_config == run_pipeline_gke.deployment_config
+    run_pipeline_gke._apply_labels_to_deployment_config(deployment_config)
+    assert expected_config == deployment_config
 
 
 def test_apply_labels_to_deployment_config_overrides(
-    run_pipeline_gke, monkeypatch
+    run_pipeline_gke, monkeypatch, deployment_config
 ):
     monkeypatch.setitem(job_gke.os.environ, "USER", "stub-user")
     monkeypatch.setattr(job_gke, "klio_cli_version", "stub-version")
 
-    input_config = {
-        "metadata": {
-            "name": "test-job",
-            "labels": {"app": "different-app-name"},
-        }
-    }
-    monkeypatch.setattr(run_pipeline_gke, "_deployment_config", input_config)
-
-    expected_config = {
-        "metadata": {
-            "name": "test-job",
-            "labels": {"app": "different-app-name"},
-        },
-        "spec": {
-            "template": {
-                "metadata": {
-                    "labels": {
-                        "app": "different-app-name",
-                        "role": "differentappname",
-                        "klio/deployed_by": "stub-user",
-                        "klio/klio_cli_version": "stub-version",
-                    }
-                },
-            },
-            "selector": {
-                "matchLabels": {
-                    "app": "different-app-name",
-                    "role": "differentappname",
-                }
-            },
-        },
+    labels = {
+        "app": "different-app-name",
+        "role": "differentappname",
+        "klio/deployed_by": "stub-user",
+        "klio/klio_cli_version": "stub-version",
     }
 
-    run_pipeline_gke._apply_labels_to_deployment_config()
-    assert expected_config == run_pipeline_gke.deployment_config
+    expected_config = deployment_config.copy()
+    glom.assign(expected_config, "spec.template.metadata.labels", labels)
+
+    run_pipeline_gke._apply_labels_to_deployment_config(deployment_config)
+    assert expected_config == deployment_config
+
+
+def test_get_deployment_config(run_pipeline_gke, deployment_config):
+    config = run_pipeline_gke.get_deployment_config(
+        config_dir=TEST_K8S_DIRECTORY
+    )
+    assert config == deployment_config
 
 
 # Tests for user facing functions
@@ -516,17 +438,16 @@ def test_apply_labels_to_deployment_config_overrides(
         (False, True, True),
     ),
 )
-def test_apply_deployment(
+def test_apply_resource(
     monkeypatch,
     mocker,
     run_pipeline_gke,
     run_job_config,
     active_context,
     docker_runtime_config,
+    mock_api_instance,
+    dynamic_client,
     deployment_config,
-    deployment_resp,
-    deployment_response_list,
-    deployment_response_list_not_exist,
     deployment_exists,
     update_flag,
     mismatched_image,
@@ -536,6 +457,11 @@ def test_apply_deployment(
     caplog_counter = 0
     test_image_base = "test-image"
     run_job_config = run_job_config._replace(update=update_flag)
+    if not deployment_exists:
+        mock_instance_response = mocker.Mock()
+        mock_instance_response.items = []
+        mock_api_instance.get.return_value = mock_instance_response
+    dynamic_client.resources.get.return_value = mock_api_instance
     if mismatched_image:
         monkeypatch.setattr(
             run_pipeline_gke.klio_config.pipeline_options,
@@ -543,38 +469,25 @@ def test_apply_deployment(
             test_image_base,
         )
     monkeypatch.setattr(run_pipeline_gke, "run_job_config", run_job_config)
-    mock_k8s_client = mocker.Mock()
-    mock_k8s_client.create_namespaced_deployment.return_value = deployment_resp
-    mock_k8s_client.patch_namespaced_deployment.return_value = deployment_resp
-    mock_k8s_client.list_namespaced_deployment.return_value = (
-        deployment_response_list
-        if deployment_exists
-        else deployment_response_list_not_exist
-    )
-    monkeypatch.setattr(
-        run_pipeline_gke, "_kubernetes_client", mock_k8s_client
-    )
+    dynamic_client.resources.get.return_value = mock_api_instance
     monkeypatch.setattr(
         run_pipeline_gke, "_kubernetes_active_context", active_context
     )
-    monkeypatch.setattr(
-        run_pipeline_gke, "_deployment_config", deployment_config
-    )
-    deployment_name = glom.glom(deployment_config, "metadata.name")
+    monkeypatch.setattr(run_pipeline_gke, "_dynamic_client", dynamic_client)
+    kind = glom.glom(deployment_config, "kind")
+    resource_name = glom.glom(deployment_config, "metadata.name")
     namespace = glom.glom(deployment_config, "metadata.namespace")
     image_path = "spec.template.spec.containers.0.image"
     image_base = glom.glom(deployment_config, image_path)
     k8s_image = f"{image_base}:{docker_runtime_config.image_tag}"
-    run_pipeline_gke._apply_image_to_deployment_config()
-    run_pipeline_gke._apply_deployment()
-    assert (
-        glom.glom(run_pipeline_gke._deployment_config, image_path) == k8s_image
-    )
+    run_pipeline_gke._apply_resource(deployment_config)
+    run_pipeline_gke._apply_image_to_deployment_config(deployment_config)
+    assert glom.glom(deployment_config, image_path) == k8s_image
     glom.assign(deployment_config, image_path, k8s_image)
     if deployment_exists:
         if update_flag:
-            mock_k8s_client.patch_namespaced_deployment.assert_called_once_with(
-                name=deployment_name,
+            mock_api_instance.patch.assert_called_once_with(
+                name=resource_name,
                 namespace=namespace,
                 body=deployment_config,
             )
@@ -582,15 +495,15 @@ def test_apply_deployment(
         else:
             caplog_counter += 1
     else:
-        mock_k8s_client.create_namespaced_deployment.assert_called_once_with(
+        mock_api_instance.create.assert_called_once_with(
             body=deployment_config, namespace=namespace
         )
         caplog_counter += 1
 
     if deployment_exists and not update_flag:
         assert caplog.records[-1].msg == (
-            f"Cannot apply deployment for {deployment_name}. "
-            "To update an existing deployment, run "
+            f"Cannot apply {kind} for {resource_name}. "
+            "To update an existing resource, run "
             "`klio job run --update`, or set `pipeline_options.update`"
             " to `True` in the job's`klio-job.yaml` file. "
             "Run `klio job stop` to scale a deployment down to 0. "
@@ -600,7 +513,7 @@ def test_apply_deployment(
     if mismatched_image:
         caplog_counter += 1
         built_image = f"{test_image_base}:{docker_runtime_config.image_tag}"
-        assert caplog.records[0].msg == (
+        assert caplog.records[-1].msg == (
             f"Image deployed by kubernetes {k8s_image} does not match "
             f"the built image {built_image}. "
             "This may result in an `ImagePullBackoff` for the deployment. "
@@ -612,34 +525,56 @@ def test_apply_deployment(
     assert len(caplog.records) == caplog_counter
 
 
+def test_apply_all_resources(
+    monkeypatch,
+    mocker,
+    run_pipeline_gke,
+    run_job_config,
+    active_context,
+    mock_api_instance,
+    dynamic_client,
+    deployment_config,
+    hpa_config,
+):
+    # Testing when no resources exists
+    mock_instance_response = mocker.Mock()
+    mock_instance_response.items = []
+    mock_api_instance.get.return_value = mock_instance_response
+    dynamic_client.resources.get.return_value = mock_api_instance
+    monkeypatch.setattr(run_pipeline_gke, "run_job_config", run_job_config)
+    monkeypatch.setattr(
+        run_pipeline_gke, "_kubernetes_active_context", active_context
+    )
+    monkeypatch.setattr(run_pipeline_gke, "_dynamic_client", dynamic_client)
+    config_directory = "tests/commands/job/kubernetes"
+    run_pipeline_gke._apply_all_resources(config_dir=config_directory)
+    mock_api_instance.create.mock_calls == (
+        [
+            mocker.call(body=deployment_config, namespace="sigint"),
+            mocker.call(body=hpa_config, namespace="sigint"),
+        ]
+    )
+
+
 def test_delete(
     monkeypatch,
     mocker,
-    deployment_response_list,
     deployment_config,
+    dynamic_client,
+    mock_api_instance,
     active_context,
 ):
     namespace = glom.glom(deployment_config, "metadata.namespace")
     deployment_name = glom.glom(deployment_config, "metadata.name")
-    mock_k8s_client = mocker.Mock()
-    mock_k8s_client.patch_namespaced_deployment.return_value = deployment_resp
-    mock_k8s_client.list_namespaced_deployment.return_value = (
-        deployment_response_list
-    )
 
     delete_pipeline_gke = job_gke.DeletePipelineGKE("/some/job/dir")
-
-    monkeypatch.setattr(
-        delete_pipeline_gke, "_kubernetes_client", mock_k8s_client
-    )
+    dynamic_client.resources.get.return_value = mock_api_instance
     monkeypatch.setattr(
         delete_pipeline_gke, "_kubernetes_active_context", active_context
     )
-    monkeypatch.setattr(
-        delete_pipeline_gke, "_deployment_config", deployment_config
-    )
-    delete_pipeline_gke.delete()
-    mock_k8s_client.delete_namespaced_deployment.assert_called_once_with(
+    monkeypatch.setattr(delete_pipeline_gke, "_dynamic_client", dynamic_client)
+    delete_pipeline_gke._delete_resource(deployment_config)
+    mock_api_instance.delete.assert_called_once_with(
         name=deployment_name,
         namespace=namespace,
         body=k8s_client.V1DeleteOptions(
@@ -648,34 +583,42 @@ def test_delete(
     )
 
 
+@pytest.mark.parametrize(
+    "is_exists", (True, False),
+)
 def test_stop(
-    deployment_resp, deployment_config, active_context, monkeypatch, mocker
+    is_exists,
+    deployment_config,
+    mock_api_instance,
+    dynamic_client,
+    active_context,
+    monkeypatch,
+    mocker,
 ):
+
     deployment_name = glom.glom(deployment_config, "metadata.name")
     namespace = glom.glom(deployment_config, "metadata.namespace")
-    mock_k8s_client = mocker.Mock()
-    mock_k8s_client.patch_namespaced_deployment.return_value = deployment_resp
-
+    if not is_exists:
+        mock_instance_response = mocker.Mock()
+        mock_instance_response.items = []
+        mock_api_instance.get.return_value = mock_instance_response
+    dynamic_client.resources.get.return_value = mock_api_instance
     stop_pipeline_gke = job_gke.StopPipelineGKE("/some/job/dir")
 
-    monkeypatch.setattr(
-        stop_pipeline_gke, "_kubernetes_client", mock_k8s_client
-    )
+    monkeypatch.setattr(stop_pipeline_gke, "_dynamic_client", dynamic_client)
     monkeypatch.setattr(
         stop_pipeline_gke, "_kubernetes_active_context", active_context
     )
-    monkeypatch.setattr(
-        stop_pipeline_gke, "_deployment_config", deployment_config
-    )
-    stop_pipeline_gke.stop()
-    mock_k8s_client.patch_namespaced_deployment.assert_called_once_with(
-        name=deployment_name, namespace=namespace, body=deployment_config,
+    # Stop functions
+    stop_pipeline_gke._edit_deployment(deployment_config, replica_count=0)
+    stop_pipeline_gke._update_resource(deployment_config)
+    mock_api_instance.patch.assert_called_once_with(
+        name=deployment_name, namespace=namespace, body=deployment_config
     )
 
 
 def test_gke_mixin_build_ui_link(mocker, monkeypatch, deployment_config):
     g = job_gke.GKECommandMixin()
-    monkeypatch.setattr(g, "_deployment_config", deployment_config)
     monkeypatch.setattr(
         g,
         "_kubernetes_active_context",
@@ -686,4 +629,4 @@ def test_gke_mixin_build_ui_link(mocker, monkeypatch, deployment_config):
         "/some-region/some-region-cluster123/sigint/gke-baseline-random-music"
         "/overview?project=test-project"
     )
-    assert expected == g._build_ui_link_from_current_context()
+    assert expected == g._build_ui_link_from_current_context(deployment_config)

--- a/docs/src/reference/cli/changelog.rst
+++ b/docs/src/reference/cli/changelog.rst
@@ -1,6 +1,21 @@
 CLI Changelog
 =============
 
+.. _cli-21.9.0:
+
+21.9.0 (UNRELEASED)
+-------------------
+
+.. start-21.9.0
+
+Added
+*****
+
+* Support for applying and deleting all resource (e.g., deployment, hpa, vpa)
+    types configured in yaml files in a job's kubernetes directory.
+
+.. end-21.9.0
+
 .. _cli-21.8.0:
 
 21.8.0 (2021-09-03)


### PR DESCRIPTION
## Changes

klio-cli will now look in the kubernetes directory and respect all yaml files.

Workflow:

`klio job run`: Iterate through each *.yaml, if the resource exists it will warn a user that it already exists and they should use the `--update` flag; If the resource does not exist it will create the resource.

`klio job delete`: Iterate through each *.yaml, if the resource exists, it will be deleted

`klio job stop`: Find the first  *.yaml that contains kind=Deployment. This config will be used to scale the deployment to 0 replicas.

## Testing
Adjusted unit tests as well as tested manually

## Checklist for PR author(s)
- [x] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [x] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [x] Document any relevant additions/changes in the appropriate spot in `docs/src`.
- [x] For any change that affects users, update the package's changelog in ``docs/src/reference/<package>/changelog.rst``.

