### PR TITLE
[lib] replace config thread-local with global and thread lock

### DIFF
--- a/docs/src/reference/lib/changelog.rst
+++ b/docs/src/reference/lib/changelog.rst
@@ -1,6 +1,21 @@
 Changelog
 =========
 
+.. _lib-21.9.0:
+
+21.9.0 (UNRELEASED)
+-------------------
+
+.. start-21.9.0
+
+Changed
+*******
+
+* Klio's config file is now read from disk once per worker instead of once per thread (See `PR 218 <https://github.com/spotify/klio/pull/218>`_).
+
+.. end-21.9.0
+
+
 .. _lib-21.8.0:
 
 21.8.0 (2021-09-03)

--- a/lib/tests/unit/message/test_pubsub_message_manager.py
+++ b/lib/tests/unit/message/test_pubsub_message_manager.py
@@ -41,6 +41,8 @@ patcher.start()
 
 from klio.transforms import helpers  # NOQA: E402, I100, I202
 
+patcher.stop()
+
 
 @pytest.fixture
 def patch_subscriber_client(mocker, monkeypatch):

--- a/lib/tests/unit/transforms/test_core.py
+++ b/lib/tests/unit/transforms/test_core.py
@@ -161,6 +161,18 @@ def test_load_config_from_file_raises(config_dict, mocker, monkeypatch):
         core_transforms.RunConfig._load_config_from_file()
 
 
+def test_runconfig_load_once(mocker, monkeypatch):
+    # ensures config is only loaded once
+    mock_load = mocker.Mock()
+    monkeypatch.setattr(
+        core_transforms.RunConfig, "_load_config_from_file", mock_load
+    )
+    core_transforms.RunConfig._config = None
+    core_transforms.RunConfig.get()
+    core_transforms.RunConfig.get()
+    assert 1 == mock_load.call_count
+
+
 @pytest.mark.parametrize("thread_local_ret", (True, False))
 def test_job_property(thread_local_ret, mocker, monkeypatch):
     mock_func = mocker.Mock()

--- a/lib/tests/unit/transforms/test_decorators.py
+++ b/lib/tests/unit/transforms/test_decorators.py
@@ -537,3 +537,6 @@ def test_threadlimitgenerator_del_release(mocker):
 
     subfunc()
     limiter.release.assert_called_once_with()
+
+
+patcher.stop()

--- a/lib/tests/unit/transforms/test_helpers.py
+++ b/lib/tests/unit/transforms/test_helpers.py
@@ -38,6 +38,8 @@ patcher.start()
 
 from klio.transforms import helpers  # NOQA: E402, I100, I202
 
+patcher.stop()
+
 IS_PY36 = sys.version_info < (3, 7)
 
 

--- a/lib/tests/unit/transforms/test_io.py
+++ b/lib/tests/unit/transforms/test_io.py
@@ -40,6 +40,7 @@ patcher = mock.patch.object(core.RunConfig, "get", conftest._klio_config)
 patcher.start()
 from klio.transforms import io as io_transforms  # NOQA E402
 
+patcher.stop()
 
 HERE = os.path.abspath(os.path.join(os.path.abspath(__file__), os.path.pardir))
 FIXTURE_PATH = os.path.join(HERE, os.path.pardir, "fixtures")
@@ -52,6 +53,7 @@ def assert_expected_klio_msg_from_file(element):
     assert isinstance(message.data.element, bytes)
 
 
+@mock.patch.object(core.RunConfig, "get", conftest._klio_config)
 def test_read_from_file():
     file_path = os.path.join(FIXTURE_PATH, "elements_text_file.txt")
 


### PR DESCRIPTION
When doing some benchmarking on streaming Dataflow, it was observed that if a job was started with large backlog of messages in Pubsub, the job would take a while to start processing messages and seem to have some throughput problems.

It was determined that the underlying cause was twofold.
1.  Dataflow will pull as many messages from pubsub at once, and Beam will attempt to create one thread per message with no upper bound.  Thus a large backlog can result in thousands of threads created simultaneously per worker machine.
2. Klio stores its cached config in a thread-local variable, which means each spawned thread must read the file from disk at least once.  Apparently when many threads are started at once, this causes some major I/O contention, which was the source of the lockup and low throughput.

Therefore, this PR replaces the thread-local storage with simply a single global variable guarded by a thread lock.  This means that now config is only read from disk once per worker and in a thread-safe manner.

This was tested extensively on Dataflow and with backlogs of over 100k messages, all startup problems were largely eliminated.  Beam will still start many threads but they no longer pile up loading config and processing begins shortly after the first thread is spawned.

Only one small issue: I added a simple unit test but due to how we mock out `RunConfig` in other tests, the test is affected and doesn't run properly.  I unsuccessfully made a couple quick attempts to fix, so we'll have to go back and figure out a better way to handle config mocking (or eliminate the need to begin with) if we want to not skip the test.

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ ] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Document any relevant additions/changes in the appropriate spot in `docs/src`.
- [ ] For any change that affects users, update the package's changelog in ``docs/src/reference/<package>/changelog.rst``.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
