### PR TITLE
[CI] Add reusable build GH workflow

### DIFF
--- a/.github/workflows/releasing/build.yaml
+++ b/.github/workflows/releasing/build.yaml
@@ -1,0 +1,78 @@
+# "Template" workflow that can be called by other workflows as well as manually triggered
+# https://docs.github.com/en/actions/learn-github-actions/reusing-workflows
+
+name: Build Artifact & Test Local Installation
+
+on:
+  workflow_call:  # allows calls from other workflows
+    inputs:
+      package-dir:
+        description: "Directory of package to build"
+        required: true
+        type: string
+      package-name:
+        description: "Name of package to build"
+        required: true
+        type: string
+  workflow_dispatch:  # manual trigger
+    inputs:
+      package-dir:
+        description: "Directory of package to build"
+        required: true
+        type: string
+      package-name:
+        description: "Name of package to build"
+        required: true
+        type: string
+
+jobs:
+  build_install:
+    name: "Build & Install ${{ github.event.inputs.package-name }}"
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v2"
+      - name: Set up Python 3.8
+        uses: "actions/setup-python@v2"
+        with:
+          python-version: 3.8
+
+      - name: Install pypa/build
+        run: |
+          set -xe
+          python -VV
+          python -m pip install build --user
+
+      - name: "${{ github.event.inputs.package-name }}: Build wheel & sdist"
+        working-directory: ${{ github.event.inputs.package-dir }}
+        run: |
+          set -xe
+          python -VV
+          python -m build --sdist --wheel --outdir dist/ .
+
+      # Last command in this step is to uninstall, so we can try installing
+      # the wheel after it
+      - name: "${{ github.event.inputs.package-name }}: Test sdist installation"
+        working-directory: ${{ github.event.inputs.package-dir }}
+        run: |
+          set -xe
+          python -VV
+          python -m pip install dist/*.tar.gz --user
+          python -c 'import ${{ github.event.inputs.package-name }}; print(${{ github.event.inputs.package-name }}.__version__)'
+          python -m pip uninstall -y ${{ github.event.inputs.package-name }}
+
+      - name: "${{ github.event.inputs.package-name }}: Test wheel installation"
+        working-directory: ${{ github.event.inputs.package-dir }}
+        run: |
+          set -xe
+          python -VV
+          python -m pip install dist/*.whl --user
+          python -c 'import ${{ github.event.inputs.package-name }}; print(${{ github.event.inputs.package-name }}.__version__)'
+
+      # Upload artifact so it can be downloaded & used in other releasing steps
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v2
+        working-directory: ${{ github.event.inputs.package-dir }}
+        with:
+          name: dist-${{ github.event.inputs.package-name }}
+          path: dist/*
+          retention-days: 1


### PR DESCRIPTION
<!--- Describe your changes 

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

This is the first PR of at least one other.

Overview of my thinking on how to approach this: Someone will create a `release-*` branch, update the changelogs, run `bumpversion`, and push to make a PR against `master`. Once merged into master, then the `.github/workflows/releasing/*` workflows will be kicked off that will do the building, testing installations, and uploading that's defined in `RELEASING.md`. 

This first workflow, `build.yml`, will be a "template workflow" (making use of GH's ["reusable workflow"](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows) feature) that other workflows will call.

Once this commit is merged, the plan is to first test this build workflow with a manual trigger (like we can with our unit tests [here](https://github.com/spotify/klio/actions/workflows/manual.yml) via "Run workflow"; workflow defined [here](https://github.com/spotify/klio/blob/develop/.github/workflows/manual.yml)). 

Then once it works, I'll add another workflow that calls this workflow (which has to be committed in the repo for another workflow to call it) to do the releasing.

The second, forthcoming workflow will have a few jobs that depend on this `build.yaml` workflow. All jobs will build & locally test install the artifacts (this workflow), then upload to the test PyPI and test install, then finally upload to prod PyPI and test install. The first job will be for `klio-core`. The second job will be for `klio`, `klio-cli`, `klio-devtools`, and `klio-audio` and will be dependent on the first job. The third job will be for `klio-exec` since it's dependent on `klio-core` and `klio` being built and released.

I'll be sure to also update our `RELEASING.md` docs.

Definitely open to suggestions for different approaches and such!

<!--- How have you tested this?
Some valid responses are:

* "I have included unit tests" 
* "I have included integration tests"
* "I successfully ran my jobs with this code"

-->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ ] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Document any relevant additions/changes in the appropriate spot in `docs/src`.
- [ ] For any change that affects users, update the package's changelog in ``docs/src/reference/<package>/changelog.rst``.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
