### PR TITLE
[cli] Only validate dataflow config for dataflow runner

### DIFF
--- a/cli/src/klio_cli/utils/cli_utils.py
+++ b/cli/src/klio_cli/utils/cli_utils.py
@@ -68,11 +68,18 @@ def validate_dataflow_runner_config(klio_config):
         raise SystemExit(1)
 
 
-def is_direct_runner(klio_config, direct_runner):
-    if not direct_runner:
+def is_direct_runner(klio_config, direct_runner_flag):
+    if direct_runner_flag:
+        return True
+
+    runner = klio_config.pipeline_options.runner
+    if runner == var.KlioRunner.DIRECT_RUNNER:
+        return True
+
+    if runner == var.KlioRunner.DATAFLOW_RUNNER:
         validate_dataflow_runner_config(klio_config)
 
-    return direct_runner
+    return False
 
 
 def import_gke_commands():

--- a/cli/tests/utils/test_cli_utils.py
+++ b/cli/tests/utils/test_cli_utils.py
@@ -85,21 +85,41 @@ def test_validate_dataflow_runner_config(
         cli_utils.validate_dataflow_runner_config(mock_klio_cfg)
 
 
-@pytest.mark.parametrize("direct_runner", [False, True])
-def test_is_direct_runner(mocker, monkeypatch, direct_runner):
+@pytest.mark.parametrize(
+    "config_runner,direct_runner,exp_is_direct,exp_mock_validate_df",
+    (
+        ("direct", True, True, False),
+        ("direct", False, True, False),
+        ("DirectRunner", True, True, False),
+        ("DirectRunner", False, True, False),
+        ("dataflow", True, True, False),
+        ("dataflow", False, False, True),
+        ("DataflowRunner", True, True, False),
+        ("DataflowRunner", False, False, True),
+        ("DirectGKERunner", True, True, False),
+        ("DirectGKERunner", False, False, False),
+    ),
+)
+def test_is_direct_runner(
+    mocker,
+    monkeypatch,
+    config_runner,
+    direct_runner,
+    exp_is_direct,
+    exp_mock_validate_df,
+):
     mock_klio_cfg = mocker.Mock()
+    mock_klio_cfg.pipeline_options.runner = config_runner
     mock_validate_df_config = mocker.Mock()
     monkeypatch.setattr(
         cli_utils, "validate_dataflow_runner_config", mock_validate_df_config
     )
 
-    if not direct_runner:
-        assert mock_validate_df_config.called_once_with(mock_klio_cfg)
+    act_resp = cli_utils.is_direct_runner(mock_klio_cfg, direct_runner)
 
-    assert (
-        cli_utils.is_direct_runner(mock_klio_cfg, direct_runner)
-        == direct_runner
-    )
+    assert exp_is_direct == act_resp
+    if exp_mock_validate_df:
+        mock_validate_df_config.assert_called_once_with(mock_klio_cfg)
 
 
 @pytest.mark.parametrize(

--- a/docs/src/reference/cli/changelog.rst
+++ b/docs/src/reference/cli/changelog.rst
@@ -1,6 +1,20 @@
 CLI Changelog
 =============
 
+.. _cli-21.10.0:
+
+21.10.0 (UNRELEASED)
+--------------------
+
+.. start-21.10.0
+
+Fixed
+*****
+
+* Correctly validate existence of Dataflow-related Klio config when running on Dataflow (and not just "not --direct-runner").
+
+.. end-21.10.0
+
 .. _cli-21.9.0:
 
 21.9.0 (2021-10-12)


### PR DESCRIPTION
<!--- Describe your changes 

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

We run a validation function to make sure if all the necessary config keys are defined when running on dataflow. Before, this validation check would run if the runner was either DirectGKE, or if DirectRunner was set in the config (and not using the `--direct-runner` flag).

The fix was actually to fix the function that checks if this is a direct runner or not. It had only returned True/False if `--direct-runner` was being used and totally ignored the runner config value.

<!--- How have you tested this?
Some valid responses are:

* "I have included unit tests" 
* "I have included integration tests"
* "I successfully ran my jobs with this code"

-->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [x] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [x] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [x] Document any relevant additions/changes in the appropriate spot in `docs/src`.
- [x] For any change that affects users, update the package's changelog in ``docs/src/reference/<package>/changelog.rst``.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
