### PR TITLE
[cli] Log gcloud cmds to add required GCP roles to service accts

### DIFF
--- a/cli/src/klio_cli/commands/job/verify.py
+++ b/cli/src/klio_cli/commands/job/verify.py
@@ -24,15 +24,38 @@ from google.cloud import storage
 from googleapiclient import discovery
 from googleapiclient import errors as google_errors
 
+from klio_core import variables as var
+
 from klio_cli.utils import stackdriver_utils as sd_utils
 
 
 GCP_ROLE_METRIC_WRITER = "roles/monitoring.metricWriter"
+GCP_ROLE_PUBLISHER = "roles/pubsub.publisher"
+GCP_ROLE_SUBSCRIBER = "roles/pubsub.subscriber"
+GCP_ROLE_STORAGE_CREATOR = "roles/storage.objectCreator"
+GCP_ROLE_STORAGE_VIEWER = "roles/storage.objectViewer"
+GCP_ROLE_LOG_WRITER = "roles/logging.logWriter"
+GCP_ROLE_SERV_ACCT_USER = "roles/iam.serviceAccountUser"
 #
 # Add any extra roles we need to check on the default service account
 # to this set:
 #
-ROLES_TO_CHECK = {GCP_ROLE_METRIC_WRITER}
+BASE_ROLES_TO_CHECK = {
+    GCP_ROLE_METRIC_WRITER,
+    GCP_ROLE_STORAGE_CREATOR,
+    GCP_ROLE_STORAGE_VIEWER,
+}
+STREAMING_ROLES_TO_CHECK = {
+    *BASE_ROLES_TO_CHECK,
+    GCP_ROLE_PUBLISHER,
+    GCP_ROLE_SUBSCRIBER,
+}
+DIRECT_GKE_ROLES_TO_CHECK = {
+    *STREAMING_ROLES_TO_CHECK,
+    GCP_ROLE_LOG_WRITER,
+    GCP_ROLE_SERV_ACCT_USER,
+}
+
 
 logging.getLogger("googleapiclient.discovery").setLevel(logging.ERROR)
 
@@ -427,13 +450,21 @@ class VerifyJob(object):
                 "unsafe project editor or owner permissions."
             )
 
-        if ROLES_TO_CHECK.issubset(svc_account_roles):
+        runner = self.klio_config.pipeline_options.runner
+        if runner == var.KlioRunner.DIRECT_GKE_RUNNER:
+            roles_to_check = DIRECT_GKE_ROLES_TO_CHECK
+        if self.klio_config.pipeline_options.streaming:
+            roles_to_check = STREAMING_ROLES_TO_CHECK
+        else:
+            roles_to_check = BASE_ROLES_TO_CHECK
+
+        if roles_to_check.issubset(svc_account_roles):
             logging.info(
                 "Verified that the service account has the required roles"
             )
             return True
 
-        missing_roles = ROLES_TO_CHECK - svc_account_roles
+        missing_roles = roles_to_check - svc_account_roles
         logging.warning(
             "The configured compute service account is missing the following "
             f"IAM role(s): {', '.join(missing_roles)}"

--- a/cli/tests/commands/job/test_verify.py
+++ b/cli/tests/commands/job/test_verify.py
@@ -127,7 +127,23 @@ def mock_create_sd_group(mocker):
                 {
                     "role": "roles/monitoring.metricWriter",
                     "members": ["serviceAccount:the-default-svc-account"],
-                }
+                },
+                {
+                    "role": "roles/pubsub.publisher",
+                    "members": ["serviceAccount:the-default-svc-account"],
+                },
+                {
+                    "role": "roles/pubsub.subscriber",
+                    "members": ["serviceAccount:the-default-svc-account"],
+                },
+                {
+                    "role": "roles/storage.objectCreator",
+                    "members": ["serviceAccount:the-default-svc-account"],
+                },
+                {
+                    "role": "roles/storage.objectViewer",
+                    "members": ["serviceAccount:the-default-svc-account"],
+                },
             ],
             False,
         ),
@@ -205,6 +221,22 @@ def test_verify_iam_roles_editor(caplog, klio_config, mock_discovery_client):
             "members": ["serviceAccount:the-default-svc-account"],
         },
         {
+            "role": "roles/pubsub.publisher",
+            "members": ["serviceAccount:the-default-svc-account"],
+        },
+        {
+            "role": "roles/pubsub.subscriber",
+            "members": ["serviceAccount:the-default-svc-account"],
+        },
+        {
+            "role": "roles/storage.objectCreator",
+            "members": ["serviceAccount:the-default-svc-account"],
+        },
+        {
+            "role": "roles/storage.objectViewer",
+            "members": ["serviceAccount:the-default-svc-account"],
+        },
+        {
             "role": "roles/editor",
             "members": ["serviceAccount:the-default-svc-account"],
         },
@@ -246,6 +278,22 @@ def test_verify_iam_roles_with_svc_account(klio_config, mock_discovery_client):
     bindings = [
         {
             "role": "roles/monitoring.metricWriter",
+            "members": ["serviceAccount:my.sa@something.com"],
+        },
+        {
+            "role": "roles/pubsub.publisher",
+            "members": ["serviceAccount:my.sa@something.com"],
+        },
+        {
+            "role": "roles/pubsub.subscriber",
+            "members": ["serviceAccount:my.sa@something.com"],
+        },
+        {
+            "role": "roles/storage.objectCreator",
+            "members": ["serviceAccount:my.sa@something.com"],
+        },
+        {
+            "role": "roles/storage.objectViewer",
             "members": ["serviceAccount:my.sa@something.com"],
         },
         {

--- a/docs/src/reference/cli/changelog.rst
+++ b/docs/src/reference/cli/changelog.rst
@@ -8,6 +8,11 @@ CLI Changelog
 
 .. start-21.10.0
 
+Added
+*****
+
+* Include more GCP roles when verifying a job's service account in ``klio job verify``.
+
 Fixed
 *****
 


### PR DESCRIPTION
<!--- Describe your changes 

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

Previously, when running `klio job verify --create-resources`, if the service account used for running the klio job (either the default SA or a configured one) didn't have the required metricWriter role, it would log an error saying that the role/permission is needed but that Klio can't add that permission for the user. 

This change adds the gcloud command(s) that users would need to run in order to add the needed roles. I chose this way instead of using an API to do it, because the API is actually [pretty risky](https://stackoverflow.com/questions/42564112/adding-roles-to-service-accounts-on-google-cloud-platform-using-rest-api#comment101358150_42567959) (it operates on the _entire_ project's IAM policy, whereas the gcloud command has the ability to operate on a single role / service account).

I also added other known GCP roles for running a job in dataflow or GKE (lmk if I missed a role or something).

Now, the logs look something like: 

```
# snip
INFO:root:Verifying IAM roles for the job's service account
WARNING:root:The configured compute service account is missing the following IAM role(s): roles/storage.objectViewer, roles/monitoring.metricWriter, roles/pubsub.publisher, roles/storage.objectCreator, roles/pubsub.subscriber
WARNING:root:Klio is unable to add the required role(s) to the service account at this time. Add them with the following gcloud command(s):
	gcloud projects add-iam-policy-binding sigint \
		--member=serviceAccount:lynn-iam-klio-cli-test@sigint.iam.gserviceaccount.com \
		--role=roles/storage.objectViewer
	gcloud projects add-iam-policy-binding sigint \
		--member=serviceAccount:lynn-iam-klio-cli-test@sigint.iam.gserviceaccount.com \
		--role=roles/monitoring.metricWriter
	gcloud projects add-iam-policy-binding sigint \
		--member=serviceAccount:lynn-iam-klio-cli-test@sigint.iam.gserviceaccount.com \
		--role=roles/pubsub.publisher
	gcloud projects add-iam-policy-binding sigint \
		--member=serviceAccount:lynn-iam-klio-cli-test@sigint.iam.gserviceaccount.com \
		--role=roles/storage.objectCreator
	gcloud projects add-iam-policy-binding sigint \
		--member=serviceAccount:lynn-iam-klio-cli-test@sigint.iam.gserviceaccount.com \
		--role=roles/pubsub.subscriber
# snip
```

<!--- How have you tested this?
Some valid responses are:

* "I have included unit tests" 
* "I have included integration tests"
* "I successfully ran my jobs with this code"

-->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [x] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [x] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [x] Document any relevant additions/changes in the appropriate spot in `docs/src`.
- [x] For any change that affects users, update the package's changelog in ``docs/src/reference/<package>/changelog.rst``.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
