### PR TITLE
[CI] Use correct template variables for workflow_dispatch; and fix version parsing

### DIFF
--- a/.github/workflows/build_upload_prod.yml
+++ b/.github/workflows/build_upload_prod.yml
@@ -103,9 +103,9 @@ jobs:
         shell: bash
         run: |
           set -xe
-          FULL_PATH=$(ls ${{ steps.download.outputs.download-path }}/*.tar.gz)
-          BASE_NAME=$(basename ${FULL_PATH} .tar.gz)
-          VERSION=$(echo ${BASE_NAME} | cut -d- -f3)
+          FULL_PATH=$(ls ${{ steps.download.outputs.download-path }}/*.whl)
+          BASE_NAME=$(basename ${FULL_PATH} .whl)
+          VERSION=$(echo ${BASE_NAME} | cut -d- -f2)
           echo ::set-output name=version::$(echo ${VERSION})
 
       - name: "Upload ${{ inputs.package-name }} artifacts to Prod PyPI"

--- a/.github/workflows/build_upload_test.yml
+++ b/.github/workflows/build_upload_test.yml
@@ -103,9 +103,9 @@ jobs:
         shell: bash
         run: |
           set -xe
-          FULL_PATH=$(ls ${{ steps.download.outputs.download-path }}/*.tar.gz)
-          BASE_NAME=$(basename ${FULL_PATH} .tar.gz)
-          VERSION=$(echo ${BASE_NAME} | cut -d- -f3)
+          FULL_PATH=$(ls ${{ steps.download.outputs.download-path }}/*.whl)
+          BASE_NAME=$(basename ${FULL_PATH} .whl)
+          VERSION=$(echo ${BASE_NAME} | cut -d- -f2)
           echo ::set-output name=version::$(echo ${VERSION})
 
       - name: "Upload ${{ inputs.package-name }} artifacts to Test PyPI"


### PR DESCRIPTION
<!--- Describe your changes 

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

This PR has two fixes in it. The first one:

When trying to run the `release.yml` workflow (that triggers the `build_upload_(test|prod).yml` workflows), it was clear that the templated input variables were not being properly populated (see [latest run](https://github.com/spotify/klio/runs/3954756088?check_suite_focus=true) of the release workflow).

It's weird - for workflows that are invoked manually (aka `on: workflow_dispatch`), the templated variables would be `${{ github.event.inputs.<variable_name> }}` ([a working example of ours](https://github.com/spotify/klio/blob/develop/.github/workflows/manual.yml#L17), [github docs](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#onworkflow_dispatchinputs)). But it seems different for workflows triggered by other workflows (aka `on: workflow_call`) - see [docs](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#onworkflow_callinputs). 

This change I think will break for manual triggers of the `build_upload_(test|prod).yml` workflows. But those manual triggers were originally meant to help with initial testing. So if this `release.yml` works, then we can remove the `on: workflow_dispatch`.

I've [asked a question](https://github.community/t/inconsistent-inputs-context-for-workflow-dispatch-and-workflow-call/207835) to the GH support community FWIW.

The second fix is to address my shitty bash-fu when trying to grab the version of the package to later test install it from test/prod PyPI.

Before, the version parsing would be correct for all packages _but_ the `klio` package. The other packages have to `-` in their name for the .tar.gz artifact, while `klio` just has one. I switched to parsing whl artifacts which has more consistent naming and therefore easier to parse.

<!--- How have you tested this?
Some valid responses are:

* "I have included unit tests" 
* "I have included integration tests"
* "I successfully ran my jobs with this code"

-->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ ] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Document any relevant additions/changes in the appropriate spot in `docs/src`.
- [ ] For any change that affects users, update the package's changelog in ``docs/src/reference/<package>/changelog.rst``.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
