### PR TITLE
Release 21.12.0rc1 including all changes that were on 21.10.0 dev releases

### DIFF
--- a/cli/setup.cfg
+++ b/cli/setup.cfg
@@ -5,7 +5,7 @@ commit = True
 tag = True
 message = [cli] Bump version: {current_version} → {new_version}
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
-serialize = 
+serialize =
 	{major}.{minor}.{patch}
 
 [bumpversion:file:src/klio_cli/__init__.py]

--- a/cli/setup.cfg
+++ b/cli/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 21.10.0.dev2
+current_version = 21.12.0rc1
 tag_name = cli-{new_version}
 commit = True
 tag = True

--- a/cli/setup.cfg
+++ b/cli/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 21.10.0.dev1
+current_version = 21.10.0.dev2
 tag_name = cli-{new_version}
 commit = True
 tag = True

--- a/cli/setup.cfg
+++ b/cli/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 21.9.0
+current_version = 21.10.0.dev1
 tag_name = cli-{new_version}
 commit = True
 tag = True

--- a/cli/src/klio_cli/__init__.py
+++ b/cli/src/klio_cli/__init__.py
@@ -14,7 +14,7 @@
 #
 
 __author__ = "The klio developers"
-__version__ = "21.9.0"
+__version__ = "21.10.0.dev1"
 __email__ = "opensource+klio@spotify.com"
 __description__ = "Main entrypoint for Klio jobs"
 __uri__ = "https://github.com/spotify/klio"

--- a/cli/src/klio_cli/__init__.py
+++ b/cli/src/klio_cli/__init__.py
@@ -14,7 +14,7 @@
 #
 
 __author__ = "The klio developers"
-__version__ = "21.10.0.dev1"
+__version__ = "21.10.0.dev2"
 __email__ = "opensource+klio@spotify.com"
 __description__ = "Main entrypoint for Klio jobs"
 __uri__ = "https://github.com/spotify/klio"

--- a/cli/src/klio_cli/__init__.py
+++ b/cli/src/klio_cli/__init__.py
@@ -14,7 +14,7 @@
 #
 
 __author__ = "The klio developers"
-__version__ = "21.10.0.dev2"
+__version__ = "21.12.0rc1"
 __email__ = "opensource+klio@spotify.com"
 __description__ = "Main entrypoint for Klio jobs"
 __uri__ = "https://github.com/spotify/klio"

--- a/cli/src/klio_cli/utils/cli_utils.py
+++ b/cli/src/klio_cli/utils/cli_utils.py
@@ -115,7 +115,7 @@ def error_stackdriver_logger_metrics(klio_config, direct_runner):
         if stackdriver_conf not in (False, None):
             msg = (
                 "The Stackdriver log-based metric client has been deprecated "
-                "since 21.3.0 and removed in 21.10.0, in favor of the Native "
+                "since 21.3.0 and removed in 21.12.0, in favor of the Native "
                 "metrics client.\n"
                 "See docs on how to turn on the native client for Dataflow: "
                 "https://docs.klio.io/en/stable/userguide/pipeline/metrics.html"

--- a/core/setup.cfg
+++ b/core/setup.cfg
@@ -1,11 +1,11 @@
 [bumpversion]
-current_version = 21.10.0.dev2
+current_version = 21.12.0rc1
 commit = True
 tag = True
 tag_name = core-{new_version}
 message = [core] Bump version: {current_version} → {new_version}
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
-serialize = 
+serialize =
 	{major}.{minor}.{patch}
 
 [bumpversion:file:src/klio_core/__init__.py]

--- a/core/setup.cfg
+++ b/core/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 21.9.0
+current_version = 21.10.0.dev1
 commit = True
 tag = True
 tag_name = core-{new_version}

--- a/core/setup.cfg
+++ b/core/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 21.10.0.dev1
+current_version = 21.10.0.dev2
 commit = True
 tag = True
 tag_name = core-{new_version}

--- a/core/src/klio_core/__init__.py
+++ b/core/src/klio_core/__init__.py
@@ -14,7 +14,7 @@
 #
 
 __author__ = "The klio developers"
-__version__ = "21.10.0.dev2"
+__version__ = "21.12.0rc1"
 __email__ = "opensource+klio@spotify.com"
 __description__ = "Core klio library for common functionality"
 __uri__ = "https://github.com/spotify/klio"

--- a/core/src/klio_core/__init__.py
+++ b/core/src/klio_core/__init__.py
@@ -14,7 +14,7 @@
 #
 
 __author__ = "The klio developers"
-__version__ = "21.9.0"
+__version__ = "21.10.0.dev1"
 __email__ = "opensource+klio@spotify.com"
 __description__ = "Core klio library for common functionality"
 __uri__ = "https://github.com/spotify/klio"

--- a/core/src/klio_core/__init__.py
+++ b/core/src/klio_core/__init__.py
@@ -14,7 +14,7 @@
 #
 
 __author__ = "The klio developers"
-__version__ = "21.10.0.dev1"
+__version__ = "21.10.0.dev2"
 __email__ = "opensource+klio@spotify.com"
 __description__ = "Core klio library for common functionality"
 __uri__ = "https://github.com/spotify/klio"

--- a/docs/src/reference/cli/changelog.rst
+++ b/docs/src/reference/cli/changelog.rst
@@ -1,12 +1,12 @@
 CLI Changelog
 =============
 
-.. _cli-21.10.0:
+.. _cli-21.12.0:
 
-21.10.0 (UNRELEASED)
+21.12.0 (UNRELEASED)
 --------------------
 
-.. start-21.10.0
+.. start-21.12.0
 
 Added
 *****
@@ -25,7 +25,7 @@ Changed
 * When running a job, effective config is no longer written to ``klio-job-run-effective.yaml``, but instead to a temp file.  This file no longer needs to be included in ``setup.py`` projects (See `PR 233 <https://github.com/spotify/klio/pull/233>`_).
 * Error out when a user tries to run a Dataflow-based job with Stackdriver log-based metrics client configured.
 
-.. end-21.10.0
+.. end-21.12.0
 
 .. _cli-21.9.0:
 

--- a/docs/src/reference/cli/changelog.rst
+++ b/docs/src/reference/cli/changelog.rst
@@ -23,6 +23,7 @@ Changed
 *******
 
 * When running a job, effective config is no longer written to ``klio-job-run-effective.yaml``, but instead to a temp file.  This file no longer needs to be included in ``setup.py`` projects (See `PR 233 <https://github.com/spotify/klio/pull/233>`_).
+* Error out when a user tries to run a Dataflow-based job with Stackdriver log-based metrics client configured.
 
 .. end-21.10.0
 

--- a/docs/src/reference/core/changelog.rst
+++ b/docs/src/reference/core/changelog.rst
@@ -1,6 +1,21 @@
 Changelog
 =========
 
+.. _core-21.10.0:
+
+21.10.0 (UNRELEASED)
+--------------------
+
+.. start-21.10.0
+
+Added
+*****
+
+* Added all supported runners to Klio ``variables``.
+
+.. end-21.10.0
+
+
 .. _core-21.9.0:
 
 21.9.0 (2021-10-12)

--- a/docs/src/reference/core/changelog.rst
+++ b/docs/src/reference/core/changelog.rst
@@ -1,20 +1,16 @@
 Changelog
 =========
 
-.. _core-21.10.0:
+.. _core-21.12.0:
 
-21.10.0 (UNRELEASED)
+21.12.0 (UNRELEASED)
 --------------------
 
-.. start-21.10.0
+.. start-21.12.0
 
-Added
-*****
+No changes - bump version to sync with ``21.12.0`` release.
 
-* Added all supported runners to Klio ``variables``.
-
-.. end-21.10.0
-
+.. end-21.12.0
 
 .. _core-21.9.0:
 

--- a/docs/src/reference/executor/changelog.rst
+++ b/docs/src/reference/executor/changelog.rst
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+.. _exec-21.10.0:
+
+21.10.0 (UNRELEASED)
+--------------------
+
+.. start-21.10.0
+
+No changes - bump version to sync with ``21.10.0`` release.
+
+.. end-21.10.0
+
 .. _exec-21.9.0:
 
 21.9.0 (2021-10-12)

--- a/docs/src/reference/executor/changelog.rst
+++ b/docs/src/reference/executor/changelog.rst
@@ -1,16 +1,16 @@
 Changelog
 =========
 
-.. _exec-21.10.0:
+.. _exec-21.12.0:
 
-21.10.0 (UNRELEASED)
+21.12.0 (UNRELEASED)
 --------------------
 
-.. start-21.10.0
+.. start-21.12.0
 
-No changes - bump version to sync with ``21.10.0`` release.
+No changes - bump version to sync with ``21.12.0`` release.
 
-.. end-21.10.0
+.. end-21.12.0
 
 .. _exec-21.9.0:
 

--- a/docs/src/reference/lib/changelog.rst
+++ b/docs/src/reference/lib/changelog.rst
@@ -1,5 +1,6 @@
 Changelog
 =========
+
 .. _lib-21.10.0:
 
 21.10.0 (UNRELEASED)
@@ -21,20 +22,6 @@ Changes
 *******
 
 * Updated documentation related to the native metrics client.
-
-
-.. end-21.10.0
-
-.. _lib-21.10.0:
-
-21.10.0 (UNRELEASED)
---------------------
-
-.. start-21.10.0
-
-Changed
-*******
-
 * ``KlioConfig`` is now loaded on workers from pickled main session instead of a bundled config file (See `PR 220 <https://github.com/spotify/klio/pull/220>`_).
 
 .. end-21.10.0

--- a/docs/src/reference/lib/changelog.rst
+++ b/docs/src/reference/lib/changelog.rst
@@ -1,36 +1,12 @@
 Changelog
 =========
-.. _lib-21.10.0:
 
-21.10.0 (UNRELEASED)
+.. _lib-21.12.0:
+
+21.12.0 (UNRELEASED)
 --------------------
 
-.. start-21.10.0
-
-Fixed
-*****
-
-* Fixed bug in metrics parsing when metrics configuration was set to a bool instead of a dict.
-
-Removed
-*******
-
-* Removed deprecated Stackdriver log-based metrics client.
-
-Changes
-*******
-
-* Updated documentation related to the native metrics client.
-
-
-.. end-21.10.0
-
-.. _lib-21.10.0:
-
-21.10.0 (UNRELEASED)
---------------------
-
-.. start-21.10.0
+.. start-21.12.0
 
 Fixed
 *****
@@ -48,7 +24,7 @@ Changes
 * Updated documentation related to the native metrics client.
 * ``KlioConfig`` is now loaded on workers from pickled main session instead of a bundled config file (See `PR 220 <https://github.com/spotify/klio/pull/220>`_).
 
-.. end-21.10.0
+.. end-21.12.0
 
 
 .. _lib-21.9.0:

--- a/docs/src/reference/lib/changelog.rst
+++ b/docs/src/reference/lib/changelog.rst
@@ -1,5 +1,29 @@
 Changelog
 =========
+.. _lib-21.10.0:
+
+21.10.0 (UNRELEASED)
+--------------------
+
+.. start-21.10.0
+
+Fixed
+*****
+
+* Fixed bug in metrics parsing when metrics configuration was set to a bool instead of a dict.
+
+Removed
+*******
+
+* Removed deprecated Stackdriver log-based metrics client.
+
+Changes
+*******
+
+* Updated documentation related to the native metrics client.
+
+
+.. end-21.10.0
 
 .. _lib-21.10.0:
 

--- a/docs/src/reference/lib/changelog.rst
+++ b/docs/src/reference/lib/changelog.rst
@@ -35,7 +35,7 @@ Changes
 Changed
 *******
 
-* ``KlioConfig`` is now loaded on workers from pickled main session instead of a bundled config file (See `PR 233 <https://github.com/spotify/klio/pull/233>`_).
+* ``KlioConfig`` is now loaded on workers from pickled main session instead of a bundled config file (See `PR 220 <https://github.com/spotify/klio/pull/220>`_).
 
 .. end-21.10.0
 

--- a/exec/setup.cfg
+++ b/exec/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 21.10.0.dev1
+current_version = 21.10.0.dev2
 commit = True
 tag = True
 tag_name = exec-{new_version}

--- a/exec/setup.cfg
+++ b/exec/setup.cfg
@@ -5,7 +5,7 @@ tag = True
 tag_name = exec-{new_version}
 message = [exec] Bump version: {current_version} → {new_version}
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
-serialize = 
+serialize =
 	{major}.{minor}.{patch}
 
 [bumpversion:file:src/klio_exec/__init__.py]

--- a/exec/setup.cfg
+++ b/exec/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 21.9.0
+current_version = 21.10.0.dev1
 commit = True
 tag = True
 tag_name = exec-{new_version}

--- a/exec/setup.cfg
+++ b/exec/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 21.10.0.dev2
+current_version = 21.12.0rc1
 commit = True
 tag = True
 tag_name = exec-{new_version}

--- a/exec/src/klio_exec/__init__.py
+++ b/exec/src/klio_exec/__init__.py
@@ -14,7 +14,7 @@
 #
 
 __author__ = "The klio developers"
-__version__ = "21.10.0.dev1"
+__version__ = "21.10.0.dev2"
 __email__ = "opensource+klio@spotify.com"
 __description__ = "Klio pipeline executor within a job's Docker image."
 __uri__ = "https://github.com/spotify/klio"

--- a/exec/src/klio_exec/__init__.py
+++ b/exec/src/klio_exec/__init__.py
@@ -14,7 +14,7 @@
 #
 
 __author__ = "The klio developers"
-__version__ = "21.10.0.dev2"
+__version__ = "21.12.0rc1"
 __email__ = "opensource+klio@spotify.com"
 __description__ = "Klio pipeline executor within a job's Docker image."
 __uri__ = "https://github.com/spotify/klio"

--- a/exec/src/klio_exec/__init__.py
+++ b/exec/src/klio_exec/__init__.py
@@ -14,7 +14,7 @@
 #
 
 __author__ = "The klio developers"
-__version__ = "21.9.0"
+__version__ = "21.10.0.dev1"
 __email__ = "opensource+klio@spotify.com"
 __description__ = "Klio pipeline executor within a job's Docker image."
 __uri__ = "https://github.com/spotify/klio"

--- a/lib/setup.cfg
+++ b/lib/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 21.10.0.dev2
+current_version = 21.12.0rc1
 commit = True
 tag = True
 tag_name = lib-{new_version}

--- a/lib/setup.cfg
+++ b/lib/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 21.10.0.dev1
+current_version = 21.10.0.dev2
 commit = True
 tag = True
 tag_name = lib-{new_version}

--- a/lib/setup.cfg
+++ b/lib/setup.cfg
@@ -5,7 +5,7 @@ tag = True
 tag_name = lib-{new_version}
 message = [lib] Bump version: {current_version} → {new_version}
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
-serialize = 
+serialize =
 	{major}.{minor}.{patch}
 
 [bumpversion:file:src/klio/__init__.py]

--- a/lib/setup.cfg
+++ b/lib/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 21.9.0
+current_version = 21.10.0.dev1
 commit = True
 tag = True
 tag_name = lib-{new_version}

--- a/lib/src/klio/__init__.py
+++ b/lib/src/klio/__init__.py
@@ -14,7 +14,7 @@
 #
 
 __author__ = "The klio developers"
-__version__ = "21.10.0.dev2"
+__version__ = "21.12.0rc1"
 __email__ = "opensource+klio@spotify.com"
 __description__ = "Conventions for Python + Apache Beam "
 __uri__ = "https://github.com/spotify/klio"

--- a/lib/src/klio/__init__.py
+++ b/lib/src/klio/__init__.py
@@ -14,7 +14,7 @@
 #
 
 __author__ = "The klio developers"
-__version__ = "21.10.0.dev1"
+__version__ = "21.10.0.dev2"
 __email__ = "opensource+klio@spotify.com"
 __description__ = "Conventions for Python + Apache Beam "
 __uri__ = "https://github.com/spotify/klio"

--- a/lib/src/klio/__init__.py
+++ b/lib/src/klio/__init__.py
@@ -14,7 +14,7 @@
 #
 
 __author__ = "The klio developers"
-__version__ = "21.9.0"
+__version__ = "21.10.0.dev1"
 __email__ = "opensource+klio@spotify.com"
 __description__ = "Conventions for Python + Apache Beam "
 __uri__ = "https://github.com/spotify/klio"


### PR DESCRIPTION
These changes include everything that was on branch `release-21.10.0`

Minimal diff comparing `21.12.0rc1` releases to up to date `21.10.0` can be seen here:

https://github.com/spotify/klio/compare/release-21.10.0...shireenk/release-21.12.0rc1?expand=1

These tags were created off of the latest commit on `shireenk/release-21.12.0rc1`

```
To github.com:spotify/klio.git
 * [new tag]         cli-21.12.0rc1 -> cli-21.12.0rc1
 * [new tag]         core-21.12.0rc1 -> core-21.12.0rc1
 * [new tag]         exec-21.12.0rc1 -> exec-21.12.0rc1
 * [new tag]         lib-21.12.0rc1 -> lib-21.12.0rc1
 ```

