### PR TITLE
[CI] Add manual trigger to build+upload workflow

### DIFF
--- a/.github/workflows/build_upload_prod.yml
+++ b/.github/workflows/build_upload_prod.yml
@@ -4,7 +4,11 @@
 name: Build & Upload to Prod PyPI
 
 on:
+  # NOTICE: accessing input/secret variables differ between workflow_call and
+  # workflow_dispatch. See https://github.community/t/inconsistent-inputs-context-for-workflow-dispatch-and-workflow-call/207835
   workflow_call:  # allows calls from other workflows
+  # to access inputs: {{ inputs.<variable_name> }}
+  # to access secrets: {{ secrets.token }}
     inputs:
       package-dir:
         description: "Directory of package to build & upload"
@@ -17,10 +21,22 @@ on:
     secrets:
       token:
         required: true
+  workflow_dispatch:  # manual trigger
+  # to access inputs: {{ github.event.inputs.<variable_name> }}
+  # to access secrets: {{ secrets.PROD_PYPI_API_TOKEN }}
+    inputs:
+      package-dir:
+        description: "Directory of package to build & upload"
+        required: true
+        type: string
+      package-name:
+        description: "Import name of package (e.g. klio_core, not klio-core)"
+        required: true
+        type: string
 
 jobs:
   build_install:
-    name: "Build & Install ${{ inputs.package-name }}"
+    name: "Build & Install ${{ inputs.package-name || github.event.inputs.package-name }}"
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v2"
@@ -35,63 +51,63 @@ jobs:
           python -VV
           python -m pip install build virtualenv twine --user
 
-      - name: "${{ inputs.package-name }}: Build wheel & sdist"
+      - name: "${{ inputs.package-name || github.event.inputs.package-name }}: Build wheel & sdist"
         run: |
           set -xe
           pwd
           python -VV
-          python -m build --sdist --wheel --outdir ${{ inputs.package-dir }}/dist/ ${{ inputs.package-dir }}/
+          python -m build --sdist --wheel --outdir ${{ inputs.package-dir || github.event.inputs.package-dir }}/dist/ ${{ inputs.package-dir || github.event.inputs.package-dir }}/
 
-      - name: "${{ inputs.package-name }}: Check Long Description"
+      - name: "${{ inputs.package-name || github.event.inputs.package-name }}: Check Long Description"
         run: |
           set -xe
           python -VV
-          python -m twine check ${{ inputs.package-dir }}/dist/*
+          python -m twine check ${{ inputs.package-dir || github.event.inputs.package-dir }}/dist/*
 
-      - name: "${{ inputs.package-name }}: Test sdist installation from local build"
+      - name: "${{ inputs.package-name || github.event.inputs.package-name }}: Test sdist installation from local build"
         run: |
           set -xe
           python -VV
           python -m virtualenv sdist-test
           source sdist-test/bin/activate
-          python -m pip install ${{ inputs.package-dir }}/dist/*.tar.gz
-          python -c 'import ${{ inputs.package-name }}; print(${{ inputs.package-name }}.__version__)'
+          python -m pip install ${{ inputs.package-dir || github.event.inputs.package-dir }}/dist/*.tar.gz
+          python -c 'import ${{ inputs.package-name || github.event.inputs.package-name }}; print(${{ inputs.package-name || github.event.inputs.package-name }}.__version__)'
           deactivate
 
-      - name: "${{ inputs.package-name }}: Test wheel installation from local build"
+      - name: "${{ inputs.package-name || github.event.inputs.package-name }}: Test wheel installation from local build"
         run: |
           set -xe
           python -VV
           python -m virtualenv wheel-test
           source wheel-test/bin/activate
-          python -m pip install ${{ inputs.package-dir }}/dist/*.whl
-          python -c 'import ${{ inputs.package-name }}; print(${{ inputs.package-name }}.__version__)'
+          python -m pip install ${{ inputs.package-dir || github.event.inputs.package-dir }}/dist/*.whl
+          python -c 'import ${{ inputs.package-name || github.event.inputs.package-name }}; print(${{ inputs.package-name || github.event.inputs.package-name }}.__version__)'
           deactivate
 
       # Upload artifact so it can be downloaded & used in the following job
       - name: "Archive artifacts"
         uses: actions/upload-artifact@v2
         with:
-          name: dist-${{ inputs.package-name }}
-          path: ${{ inputs.package-dir }}/dist/*
+          name: dist-${{ inputs.package-name || github.event.inputs.package-name }}
+          path: ${{ inputs.package-dir || github.event.inputs.package-dir }}/dist/*
           retention-days: 1
 
   upload_prod_pypi:
-    name: "Upload ${{ inputs.package-name }} to PyPI Prod Server"
+    name: "Upload ${{ inputs.package-name || github.event.inputs.package-name }} to PyPI Prod Server"
     needs: build_install
     outputs:
       version: ${{ steps.version.outputs.version }}
     runs-on: "ubuntu-latest"
     steps:
-      - name: "Download ${{ inputs.package-name }} artifacts from GH"
+      - name: "Download ${{ inputs.package-name || github.event.inputs.package-name }} artifacts from GH"
         id: download
         uses: actions/download-artifact@v2
         with:
-          name: dist-${{ inputs.package-name }}
+          name: dist-${{ inputs.package-name || github.event.inputs.package-name }}
 
       # Save the version as a variable we can use later when we test
       # the installation
-      - name: "Grab Package Version for ${{ inputs.package-name }}"
+      - name: "Grab Package Version for ${{ inputs.package-name || github.event.inputs.package-name }}"
         id: version
         shell: bash
         run: |
@@ -101,15 +117,15 @@ jobs:
           VERSION=$(echo ${BASE_NAME} | cut -d- -f2)
           echo ::set-output name=version::$(echo ${VERSION})
 
-      - name: "Upload ${{ inputs.package-name }} artifacts to Prod PyPI"
+      - name: "Upload ${{ inputs.package-name || github.event.inputs.package-name }} artifacts to Prod PyPI"
         uses: pypa/gh-action-pypi-publish@master
         with:
-          password: ${{ secrets.token }}
+          password: ${{ secrets.token || secrets.PROD_PYPI_API_TOKEN }}
           verbose: true
           packages_dir: ${{ steps.download.outputs.download-path }}
 
   install_prod_pypi:
-    name: "Test installation of ${{ inputs.package-name }} from Prod PyPI"
+    name: "Test installation of ${{ inputs.package-name || github.event.inputs.package-name }} from Prod PyPI"
     needs: upload_prod_pypi
     runs-on: "ubuntu-latest"
     steps:
@@ -129,20 +145,20 @@ jobs:
           python -VV
           python -m pip install virtualenv --user
 
-      - name: "Test wheel install of ${{ inputs.package-name }} from Prod PyPI"
+      - name: "Test wheel install of ${{ inputs.package-name || github.event.inputs.package-name }} from Prod PyPI"
         run: |
           set -xe
           python -m virtualenv prod-pypi-wheel
           source prod-pypi-wheel/bin/activate
-          python -m pip install -i https://pypi.org/simple --only-binary=${{ inputs.package-name }} ${{ inputs.package-name }}==${{ needs.upload_prod_pypi.outputs.version }}
-          python -c 'import ${{ inputs.package-name }}; assert ${{ inputs.package-name }}.__version__ == "${{ needs.upload_prod_pypi.outputs.version }}"'
+          python -m pip install -i https://pypi.org/simple --only-binary=${{ inputs.package-name || github.event.inputs.package-name }} ${{ inputs.package-name || github.event.inputs.package-name }}==${{ needs.upload_prod_pypi.outputs.version }}
+          python -c 'import ${{ inputs.package-name || github.event.inputs.package-name }}; assert ${{ inputs.package-name || github.event.inputs.package-name }}.__version__ == "${{ needs.upload_prod_pypi.outputs.version }}"'
           deactivate
 
-      - name: "Test sdist install of ${{ inputs.package-name }} from Prod PyPI"
+      - name: "Test sdist install of ${{ inputs.package-name || github.event.inputs.package-name }} from Prod PyPI"
         run: |
           set -xe
           python -m virtualenv prod-pypi-sdist
           source prod-pypi-sdist/bin/activate
-          python -m pip install -i https://pypi.org/simple --no-binary=${{ inputs.package-name }} ${{ inputs.package-name }}==${{ needs.upload_prod_pypi.outputs.version }}
-          python -c 'import ${{ inputs.package-name }}; assert ${{ inputs.package-name }}.__version__ == "${{ needs.upload_prod_pypi.outputs.version }}"'
+          python -m pip install -i https://pypi.org/simple --no-binary=${{ inputs.package-name || github.event.inputs.package-name }} ${{ inputs.package-name || github.event.inputs.package-name }}==${{ needs.upload_prod_pypi.outputs.version }}
+          python -c 'import ${{ inputs.package-name || github.event.inputs.package-name }}; assert ${{ inputs.package-name || github.event.inputs.package-name }}.__version__ == "${{ needs.upload_prod_pypi.outputs.version }}"'
           deactivate

--- a/.github/workflows/build_upload_test.yml
+++ b/.github/workflows/build_upload_test.yml
@@ -4,7 +4,11 @@
 name: Build & Upload to Test PyPI
 
 on:
+  # NOTICE: accessing input/secret variables differ between workflow_call and
+  # workflow_dispatch. See https://github.community/t/inconsistent-inputs-context-for-workflow-dispatch-and-workflow-call/207835
   workflow_call:  # allows calls from other workflows
+  # to access inputs: {{ inputs.<variable_name> }}
+  # to access secrets: {{ secrets.token }}
     inputs:
       package-dir:
         description: "Directory of package to build & upload"
@@ -17,10 +21,22 @@ on:
     secrets:
       token:
         required: true
+  workflow_dispatch:  # manual trigger
+  # to access inputs: {{ github.event.inputs.<variable_name> }}
+  # to access secrets: {{ secrets.TEST_PYPI_API_TOKEN }}
+    inputs:
+      package-dir:
+        description: "Directory of package to build & upload"
+        required: true
+        type: string
+      package-name:
+        description: "Import name of package (e.g. klio_core, not klio-core)"
+        required: true
+        type: string
 
 jobs:
   build_install:
-    name: "Build & Install ${{ inputs.package-name }}"
+    name: "Build & Install ${{ inputs.package-name || github.event.inputs.package-name }}"
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v2"
@@ -35,63 +51,63 @@ jobs:
           python -VV
           python -m pip install build virtualenv twine --user
 
-      - name: "${{ inputs.package-name }}: Build wheel & sdist"
+      - name: "${{ inputs.package-name || github.event.inputs.package-name }}: Build wheel & sdist"
         run: |
           set -xe
           pwd
           python -VV
-          python -m build --sdist --wheel --outdir ${{ inputs.package-dir }}/dist/ ${{ inputs.package-dir }}
+          python -m build --sdist --wheel --outdir ${{ inputs.package-dir || github.event.inputs.package-dir }}/dist/ ${{ inputs.package-dir || github.event.inputs.package-dir }}
 
-      - name: "${{ inputs.package-name }}: Check Long Description"
+      - name: "${{ inputs.package-name || github.event.inputs.package-name }}: Check Long Description"
         run: |
           set -xe
           python -VV
-          python -m twine check ${{ inputs.package-dir }}/dist/*
+          python -m twine check ${{ inputs.package-dir || github.event.inputs.package-dir }}/dist/*
 
-      - name: "${{ inputs.package-name }}: Test sdist installation from local build"
+      - name: "${{ inputs.package-name || github.event.inputs.package-name }}: Test sdist installation from local build"
         run: |
           set -xe
           python -VV
           python -m virtualenv sdist-test
           source sdist-test/bin/activate
-          python -m pip install ${{ inputs.package-dir }}/dist/*.tar.gz
-          python -c 'import ${{ inputs.package-name }}; print(${{ inputs.package-name }}.__version__)'
+          python -m pip install ${{ inputs.package-dir || github.event.inputs.package-dir }}/dist/*.tar.gz
+          python -c 'import ${{ inputs.package-name || github.event.inputs.package-name }}; print(${{ inputs.package-name || github.event.inputs.package-name }}.__version__)'
           deactivate
 
-      - name: "${{ inputs.package-name }}: Test wheel installation from local build"
+      - name: "${{ inputs.package-name || github.event.inputs.package-name }}: Test wheel installation from local build"
         run: |
           set -xe
           python -VV
           python -m virtualenv wheel-test
           source wheel-test/bin/activate
-          python -m pip install ${{ inputs.package-dir }}/dist/*.whl
-          python -c 'import ${{ inputs.package-name }}; print(${{ inputs.package-name }}.__version__)'
+          python -m pip install ${{ inputs.package-dir || github.event.inputs.package-dir }}/dist/*.whl
+          python -c 'import ${{ inputs.package-name || github.event.inputs.package-name }}; print(${{ inputs.package-name || github.event.inputs.package-name }}.__version__)'
           deactivate
 
       # Upload artifact so it can be downloaded & used in the following job
       - name: "Archive artifacts"
         uses: actions/upload-artifact@v2
         with:
-          name: dist-${{ inputs.package-name }}
-          path: ${{ inputs.package-dir }}/dist/*
+          name: dist-${{ inputs.package-name || github.event.inputs.package-name }}
+          path: ${{ inputs.package-dir || github.event.inputs.package-dir }}/dist/*
           retention-days: 1
 
   upload_test_pypi:
-    name: "Upload ${{ inputs.package-name }} to PyPI Test Server"
+    name: "Upload ${{ inputs.package-name || github.event.inputs.package-name }} to PyPI Test Server"
     needs: build_install
     outputs:
       version: ${{ steps.version.outputs.version }}
     runs-on: "ubuntu-latest"
     steps:
-      - name: "Download ${{ inputs.package-name }} artifacts from GH"
+      - name: "Download ${{ inputs.package-name || github.event.inputs.package-name }} artifacts from GH"
         id: download
         uses: actions/download-artifact@v2
         with:
-          name: dist-${{ inputs.package-name }}
+          name: dist-${{ inputs.package-name || github.event.inputs.package-name }}
 
       # Save the version as a variable we can use later when we test
       # the installation
-      - name: "Grab Package Version for ${{ inputs.package-name }}"
+      - name: "Grab Package Version for ${{ inputs.package-name || github.event.inputs.package-name }}"
         id: version
         shell: bash
         run: |
@@ -101,16 +117,16 @@ jobs:
           VERSION=$(echo ${BASE_NAME} | cut -d- -f2)
           echo ::set-output name=version::$(echo ${VERSION})
 
-      - name: "Upload ${{ inputs.package-name }} artifacts to Test PyPI"
+      - name: "Upload ${{ inputs.package-name || github.event.inputs.package-name }} artifacts to Test PyPI"
         uses: pypa/gh-action-pypi-publish@master
         with:
-          password: ${{ secrets.token }}
+          password: ${{ secrets.token || secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
           verbose: true
           packages_dir: ${{ steps.download.outputs.download-path }}
 
   install_test_pypi:
-    name: "Test installation of ${{ inputs.package-name }} from Test PyPI"
+    name: "Test installation of ${{ inputs.package-name || github.event.inputs.package-name }} from Test PyPI"
     needs: upload_test_pypi
     runs-on: "ubuntu-latest"
     steps:
@@ -132,20 +148,20 @@ jobs:
 
       # Since not all of our dependencies are on the Test PyPI, we pass in
       # an `--extra-index-url` to include prod so the klio* package can be properly installed 
-      - name: "Test wheel install of ${{ inputs.package-name }} from Test PyPI"
+      - name: "Test wheel install of ${{ inputs.package-name || github.event.inputs.package-name }} from Test PyPI"
         run: |
           set -xe
           python -m virtualenv test-pypi-wheel
           source test-pypi-wheel/bin/activate
-          python -m pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple --only-binary=${{ inputs.package-name }} ${{ inputs.package-name }}==${{ needs.upload_test_pypi.outputs.version }}
-          python -c 'import ${{ inputs.package-name }}; assert ${{ inputs.package-name }}.__version__ == "${{ needs.upload_test_pypi.outputs.version }}"'
+          python -m pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple --only-binary=${{ inputs.package-name || github.event.inputs.package-name }} ${{ inputs.package-name || github.event.inputs.package-name }}==${{ needs.upload_test_pypi.outputs.version }}
+          python -c 'import ${{ inputs.package-name || github.event.inputs.package-name }}; assert ${{ inputs.package-name || github.event.inputs.package-name }}.__version__ == "${{ needs.upload_test_pypi.outputs.version }}"'
           deactivate
 
-      - name: "Test sdist install of ${{ inputs.package-name }} from Test PyPI"
+      - name: "Test sdist install of ${{ inputs.package-name || github.event.inputs.package-name }} from Test PyPI"
         run: |
           set -xe
           python -m virtualenv test-pypi-sdist
           source test-pypi-sdist/bin/activate
-          python -m pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple --no-binary=${{ inputs.package-name }} ${{ inputs.package-name }}==${{ needs.upload_test_pypi.outputs.version }}
-          python -c 'import ${{ inputs.package-name }}; assert ${{ inputs.package-name }}.__version__ == "${{ needs.upload_test_pypi.outputs.version }}"'
+          python -m pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple --no-binary=${{ inputs.package-name || github.event.inputs.package-name }} ${{ inputs.package-name || github.event.inputs.package-name }}==${{ needs.upload_test_pypi.outputs.version }}
+          python -c 'import ${{ inputs.package-name || github.event.inputs.package-name }}; assert ${{ inputs.package-name || github.event.inputs.package-name }}.__version__ == "${{ needs.upload_test_pypi.outputs.version }}"'
           deactivate


### PR DESCRIPTION
Not sure if the secrets handling works for this, though :grimacing:. I did refer to [these docs](https://github.community/t/secure-github-action-inputs/122310) that are 1.5 years old, which 🤞🏻 hopefully still works.

<!--- Describe your changes 

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

<!--- How have you tested this?
Some valid responses are:

* "I have included unit tests" 
* "I have included integration tests"
* "I successfully ran my jobs with this code"

-->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ ] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Document any relevant additions/changes in the appropriate spot in `docs/src`.
- [ ] For any change that affects users, update the package's changelog in ``docs/src/reference/<package>/changelog.rst``.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
