### PR TITLE
[docs] update installation guide links that 404

### DIFF
--- a/audio/README.rst
+++ b/audio/README.rst
@@ -23,7 +23,7 @@ To make use of ``klio-audio``, add ``klio[audio]`` in your ``job-requirements.tx
 .. start-klio-audio-install
 
 As the ``klio-audio`` library is **not** meant to be installed directly, check out the `installation
-guide <https://docs.klio.io/en/latest/quickstart/installation.html>`_ for how to setup
+guide <https://docs.klio.io/en/latest/userguide/quickstart/installation.html>`_ for how to setup
 installation.
 There is also the `user guide <https://docs.klio.io/en/latest/userguide/index.html>`_ and the `API
 documentation <https://docs.klio.io/en/latest/reference/audio/index.html>`_ for more information.

--- a/cli/README.rst
+++ b/cli/README.rst
@@ -15,5 +15,5 @@ The ``klio-cli``
 The CLI is the main entrypoint for users in interacting with a Klio job.
 This CLI is used for creating, deploying, testing, and profiling of Klio jobs, among other helpful commands.
 
-Check out the `installation guide <https://docs.klio.io/en/latest/quickstart/installation.html>`_ for how to setup installation.
+Check out the `installation guide <https://docs.klio.io/en/latest/userguide/quickstart/installation.html>`_ for how to setup installation.
 There is also the `user guide <https://docs.klio.io/en/latest/userguide/index.html>`_ and the `API documentation <https://docs.klio.io/en/latest/reference/cli/index.html>`_ for more information.

--- a/core/README.rst
+++ b/core/README.rst
@@ -13,5 +13,5 @@ The ``klio-core`` Package
 
 A library of common utilities, including the Klio `protobuf definitions <https://docs.klio.io/en/latest/userguide/pipeline/message.html>`_ and configuration parsing.
 
-As the ``klio-core`` package is **not** meant to be installed directly, check out the `installation guide <https://docs.klio.io/en/latest/quickstart/installation.html>`_ for how to setup installation.
+As the ``klio-core`` package is **not** meant to be installed directly, check out the `installation guide <https://docs.klio.io/en/latest/userguide/quickstart/installation.html>`_ for how to setup installation.
 There is also the `user guide <https://docs.klio.io/en/latest/userguide/index.html>`_ and the `API documentation <https://docs.klio.io/en/latest/reference/core/index.html>`_ for more information.

--- a/examples/catvdog/README.rst
+++ b/examples/catvdog/README.rst
@@ -4,7 +4,7 @@ Cat and Dog Image Classifier
 Requirements
 ------------
 
-* Follow the documented `installation instructions <https://docs.klio.io/en/latest/quickstart/installation.html>`_.
+* Follow the documented `installation instructions <https://docs.klio.io/en/latest/userguide/quickstart/installation.html>`_.
 * Python 3.6+
 
 Run

--- a/exec/README.rst
+++ b/exec/README.rst
@@ -16,7 +16,7 @@ The executor – **not** meant to be used directly by the user – is a CLI that
 Many commands from the ``klio-cli`` directly wrap to commands in the executor: a ``klio-cli`` command will set up the Docker context needed to correctly run the pipeline via the associated command with ``klio-exec``.
 The Docker context includes mounting the job directory, sets up environment variables, mounting credentials, etc.
 
-As the ``klio-exec`` package is **not** meant to be installed directly, check out the `installation guide <https://docs.klio.io/en/latest/quickstart/installation.html>`_ for how to setup installation.
+As the ``klio-exec`` package is **not** meant to be installed directly, check out the `installation guide <https://docs.klio.io/en/latest/userguide/quickstart/installation.html>`_ for how to setup installation.
 There is also the `user guide <https://docs.klio.io/en/latest/userguide/index.html>`_ and the `API documentation <https://docs.klio.io/en/latest/reference/executor/index.html>`_ for more information.
 
 

--- a/lib/README.rst
+++ b/lib/README.rst
@@ -13,5 +13,5 @@ The ``klio`` Library
 
 The library for implementing Klio-ified Apache Beam transforms with `decorators <https://docs.klio.io/en/latest/userguide/pipeline/utilities.html>`_, `helper transforms <https://docs.klio.io/en/latest/userguide/pipeline/transforms.html>`_, and leverage Klio's `message-handling logic <https://docs.klio.io/en/latest/userguide/pipeline/message.html>`_.
 
-As the ``klio`` library is **not** meant to be installed directly, check out the `installation guide <https://docs.klio.io/en/latest/quickstart/installation.html>`_ for how to setup installation.
+As the ``klio`` library is **not** meant to be installed directly, check out the `installation guide <https://docs.klio.io/en/latest/userguide/quickstart/installation.html>`_ for how to setup installation.
 There is also the `user guide <https://docs.klio.io/en/latest/userguide/index.html>`_ and the `API documentation <https://docs.klio.io/en/latest/reference/lib/index.html>`_ for more information.


### PR DESCRIPTION
Signed-off-by: Colton Padden <colton.padden@fastmail.com>

Closes #172.

Documentation has been updated to replace all instances of `https://docs.klio.io/en/latest/quickstart/installation.html` with `https://docs.klio.io/en/latest/userguide/quickstart/installation.html`. Occurrences of the legacy installation instructions were found by grepping the project.

Links were validated by running a local instance of sphinx via `make livehtml`.

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [x] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Document any relevant additions/changes in the appropriate spot in `docs/src`.
- [ ] For any change that affects users, update the package's changelog in ``docs/src/reference/<package>/changelog.rst``.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
