### PR TITLE
Add support for waiting until job reaches running state in streaming job

### DIFF
--- a/core/src/klio_core/config/core.py
+++ b/core/src/klio_core/config/core.py
@@ -177,9 +177,11 @@ class KlioJobConfig(object):
     version = utils.field(type=int)
 
     # optional attributes
+
     allow_non_klio_messages = utils.field(type=bool, default=False)
     metrics = utils.field(default={})
     blocking = utils.field(type=bool, default=False)
+    wait_for_pipeline_running = utils.field(type=bool, default=False)
 
     def __config_post_init__(self, config_dict):
         self._raw = config_dict

--- a/docs/src/userguide/config/job_config.rst
+++ b/docs/src/userguide/config/job_config.rst
@@ -19,6 +19,14 @@ Klio-specific and :ref:`user-specified custom <custom-conf>` job configuration.
 
     **Default**: ``False``
 
+.. option:: job_config.wait_for_pipeline_running BOOL
+
+    Wait for Streaming job to reach running state and then exit. klio pools every
+    minute for 10 minutes max. If The pipeline has not reached running status after
+    10 minutes, klio fails. If the pipeline reaches a terminal non-running state,
+    klio logs an error and exits.
+
+    **Default**: ``False``
 
 .. _custom-conf:
 .. option:: job_config.<additional_key> ANY
@@ -273,7 +281,7 @@ client depends on the runner:
 
 .. caution::
 
-    When running on Dataflow, in order for the Native metrics client to be able to report metrics to Stackdriver, 
+    When running on Dataflow, in order for the Native metrics client to be able to report metrics to Stackdriver,
     the following ``experiment`` must be added to ``klio-job.yaml``:
 
     .. code-block:: yaml

--- a/exec/src/klio_exec/commands/run.py
+++ b/exec/src/klio_exec/commands/run.py
@@ -17,12 +17,12 @@ import collections
 import imp
 import logging
 import os
-import time
 import re
+import time
 
 import apache_beam as beam
-from apache_beam.runners.runner import PipelineState, PipelineResult
 from apache_beam.options import pipeline_options
+from apache_beam.runners.runner import PipelineResult, PipelineState
 
 from klio import __version__ as klio_lib_version
 from klio import transforms
@@ -565,9 +565,9 @@ class KlioPipeline(object):
         for _ in range(0, timeout_sec, poll_interval_sec):
             try:
                 status = result.state
-                if status in PipelineState.RUNNING:
+                if status == PipelineState.RUNNING:
                     logging.info(
-                        f"Pipeline status is %s, done waiting", status,
+                        "Pipeline status is %s, done waiting", status,
                     )
                     return status
                 elif PipelineState.is_terminal(status):
@@ -575,7 +575,7 @@ class KlioPipeline(object):
                     return status
 
                 logging.info(
-                    f"Pipeline status %s not in %s, retrying in %s seconds",
+                    "Pipeline status %s not in %s, retrying in %s seconds",
                     status,
                     PipelineState.RUNNING,
                     poll_interval_sec,
@@ -586,7 +586,8 @@ class KlioPipeline(object):
             time.sleep(poll_interval_sec)
 
         raise TimeoutError(
-            f"Pipeline finished in status {status} but expected {PipelineState.RUNNING}"
+            f"Pipeline finished in status {status}"
+            f"but expected {PipelineState.RUNNING}"
         )
 
     def run(self):
@@ -636,7 +637,6 @@ class KlioPipeline(object):
             result.wait_until_finish()
 
         # If the blocking flag was already passed don't wait again
-        # import pdb; pdb.set_trace()
         if (
             self.config.job_config.wait_for_pipeline_running
             and self.config.pipeline_options.streaming

--- a/exec/src/klio_exec/commands/run.py
+++ b/exec/src/klio_exec/commands/run.py
@@ -22,7 +22,7 @@ import time
 
 import apache_beam as beam
 from apache_beam.options import pipeline_options
-from apache_beam.runners.runner import PipelineResult, PipelineState
+from apache_beam.runners import runner
 
 from klio import __version__ as klio_lib_version
 from klio import transforms
@@ -556,7 +556,7 @@ class KlioPipeline(object):
 
     def wait_for_pipeline_running(
         self,
-        result: PipelineResult,
+        pipeline_result,
         timeout_sec=10 * 60,  # 10 minutes in seconds
         poll_interval_sec=60,
     ):
@@ -564,21 +564,18 @@ class KlioPipeline(object):
 
         for _ in range(0, timeout_sec, poll_interval_sec):
             try:
-                status = result.state
-                if status == PipelineState.RUNNING:
-                    logging.info(
-                        "Pipeline status is %s, done waiting", status,
-                    )
+                status = pipeline_result.state
+                if status == runner.PipelineState.RUNNING:
+                    logging.info(f"Pipeline status is {status}, done waiting")
                     return status
-                elif PipelineState.is_terminal(status):
-                    logging.error("Pipeline already in terminal status.")
+                elif runner.PipelineState.is_terminal(status):
+                    logging.error("Pipeline already in terminal status")
                     return status
 
                 logging.info(
-                    "Pipeline status %s not in %s, retrying in %s seconds",
-                    status,
-                    PipelineState.RUNNING,
-                    poll_interval_sec,
+                    f"Pipeline status {status} is not "
+                    f"{runner.PipelineState.RUNNING}, retrying in "
+                    f"{poll_interval_sec} seconds"
                 )
             except Exception as e:
                 logging.exception(e)
@@ -586,8 +583,8 @@ class KlioPipeline(object):
             time.sleep(poll_interval_sec)
 
         raise TimeoutError(
-            f"Pipeline finished in status {status}"
-            f"but expected {PipelineState.RUNNING}"
+            f"Pipeline finished in status {status} "
+            f"but expected {runner.PipelineState.RUNNING}"
         )
 
     def run(self):

--- a/exec/tests/unit/commands/test_run.py
+++ b/exec/tests/unit/commands/test_run.py
@@ -644,7 +644,9 @@ def test_get_pipeline_options(
 )
 @pytest.mark.parametrize("blocking", (True, False))
 @pytest.mark.parametrize("streaming", (True, False))
+@pytest.mark.parametrize("wait_until_pipeline_complete", (True, False))
 def test_run_pipeline(
+    wait_until_pipeline_complete,
     streaming,
     blocking,
     direct_runner,
@@ -659,6 +661,9 @@ def test_run_pipeline(
         direct_runner=direct_runner, update=True, blocking=blocking
     )
 
+    mock_wait_until_pipeline_running = mocker.patch.object(
+        run.KlioPipeline, "wait_for_pipeline_running", autospec=True
+    )
     mock_verify_packaging = mocker.Mock()
     mock_get_run_callable = mocker.Mock()
     mock_run_callable = mocker.Mock()
@@ -711,6 +716,11 @@ def test_run_pipeline(
         config.job_config.events.inputs = [mock_input]
         config.job_config.events.outputs = [mock_output]
 
+    if wait_until_pipeline_complete and streaming:
+        config.job_config.wait_for_pipeline_running = True
+    else:
+        config.job_config.wait_for_pipeline_running = False
+
     if run_error:
         mock_pipeline.return_value.run.side_effect = [
             run_error,
@@ -750,6 +760,17 @@ def test_run_pipeline(
     if direct_runner or blocking:
         result = mock_pipeline.return_value.run.return_value
         result.wait_until_finish.assert_called_once_with()
+
+    if (
+        streaming
+        and not blocking
+        and wait_until_pipeline_complete
+        and not direct_runner
+        and config.pipeline_options.runner != "DirectGKERunner"
+    ):
+        mock_wait_until_pipeline_running.assert_called_once()
+    else:
+        mock_wait_until_pipeline_running.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/exec/tests/unit/commands/test_run.py
+++ b/exec/tests/unit/commands/test_run.py
@@ -644,9 +644,9 @@ def test_get_pipeline_options(
 )
 @pytest.mark.parametrize("blocking", (True, False))
 @pytest.mark.parametrize("streaming", (True, False))
-@pytest.mark.parametrize("wait_until_pipeline_complete", (True, False))
+@pytest.mark.parametrize("wait_until_pipeline_running", (True, False))
 def test_run_pipeline(
-    wait_until_pipeline_complete,
+    wait_until_pipeline_running,
     streaming,
     blocking,
     direct_runner,
@@ -716,8 +716,10 @@ def test_run_pipeline(
         config.job_config.events.inputs = [mock_input]
         config.job_config.events.outputs = [mock_output]
 
-    if wait_until_pipeline_complete and streaming:
-        config.job_config.wait_for_pipeline_running = True
+    if streaming:
+        config.job_config.wait_for_pipeline_running = (
+            wait_until_pipeline_running
+        )
     else:
         config.job_config.wait_for_pipeline_running = False
 
@@ -764,7 +766,7 @@ def test_run_pipeline(
     if (
         streaming
         and not blocking
-        and wait_until_pipeline_complete
+        and wait_until_pipeline_running
         and not direct_runner
         and config.pipeline_options.runner != "DirectGKERunner"
     ):


### PR DESCRIPTION
When using streaming mode, the deployment can be successful but the pipeline could actually fail shortly after. By adding a flag to wait for the job to at least get in running state we could make the CI/CD deployment wait and error if the deployment was not successful. To avoid waiting infinitely, set some defaults 
```python
        timeout_sec=10 * 60,  # 10 minutes in seconds
        poll_interval_sec=60,
```

This way we only wait a max of 10 minutes, and only pool every minutes to check for pipeline state.


I havent made the timeout seconds and poll interval configurable yet until I get feedback from devs if this a good thing to do here at all or not.

I included unittest tests but also did a local test and pipeline eventually reaches done state
<img width="687" alt="Screen Shot 2022-01-26 at 9 13 39 PM" src="https://user-images.githubusercontent.com/13670774/151281725-7b8163a5-1d34-4e20-9e2d-6e21c025fe6d.png">


-->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ ] Format the pull request title like `[cli] Fixes bugs in 'klio job fake-cmd'`.
- [ ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Document any relevant additions/changes in the appropriate spot in `docs/src`.
- [ ] For any change that affects users, update the package's changelog in ``docs/src/reference/<package>/changelog.rst``.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
