### PR TITLE
[exec] Fix if passthru pcoll is None

### DIFF
--- a/exec/setup.py
+++ b/exec/setup.py
@@ -159,9 +159,10 @@ INSTALL_REQUIRES = [
     "pyyaml",
     # 2.22 added DirectRunner support for `DoFn.setup`
     "apache-beam[gcp]>2.21.0",
-    # beam[gcp] limits this dep as well, but there could be a possibility
-    # that unsupported versions are installed (i.e. via tox)
-    "google-cloud-pubsub<2",
+    # Note: apache-beam v2.36.0 updated pubsub dep version to >=2.1.0, <3;
+    # Before 2.36.0, it was <2. Leaving no version spec here so folks can
+    # install the needed pubsub version depending on their beam version
+    "google-cloud-pubsub",
     "setuptools",  # for loading entry points w pkg_resources
     "py",
     "pytest",

--- a/exec/src/klio_exec/commands/run.py
+++ b/exec/src/klio_exec/commands/run.py
@@ -354,11 +354,14 @@ class KlioPipeline(object):
                 output_exists.found
                 | lbl("Output Force Filter") >> helpers.KlioFilterForce()
             )
-            to_pass_thru_tuple = (pass_thru, output_force.pass_thru)
-            to_pass_thru = (
-                to_pass_thru_tuple
-                | lbl("Flatten to Pass Thru") >> beam.Flatten()
-            )
+            if pass_thru is not None:
+                to_pass_thru_tuple = (pass_thru, output_force.pass_thru)
+                to_pass_thru = (
+                    to_pass_thru_tuple
+                    | lbl("Flatten to Pass Thru") >> beam.Flatten()
+                )
+            else:
+                to_pass_thru = output_force.pass_thru
 
             to_filter_input_tuple = (
                 output_exists.not_found,


### PR DESCRIPTION
We should allow users to not need to define data inputs in `klio-job.yaml`. This bug was preventing that, where a `PCollection` would be set to `None` to start with, and not updated with any pass through input pcollections since there could be no inputs to begin with. (I hope that makes sense, it's quite early in the day for me)
